### PR TITLE
Paramatize request/response payload size

### DIFF
--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -156,6 +156,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             server_target=server_target,
             rpc=rpc,
             qps=qps,
+            request_payload_size=271828,
+            response_payload_size=314159,
             metadata=metadata,
             secure_mode=secure_mode,
             config_mesh=config_mesh,

--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -107,6 +107,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
         print_response=False,
         log_to_stdout: bool = False,
         enable_csm_observability: bool = False,
+        request_payload_size: int = 0,
+        response_payload_size: int = 0,
     ) -> XdsTestClient:
         logger.info(
             (
@@ -156,8 +158,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             server_target=server_target,
             rpc=rpc,
             qps=qps,
-            request_payload_size=271828,
-            response_payload_size=314159,
+            request_payload_size=request_payload_size,
+            response_payload_size=response_payload_size,
             metadata=metadata,
             secure_mode=secure_mode,
             config_mesh=config_mesh,

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -41,8 +41,12 @@ spec:
           - "--qps=${qps}"
           - "--rpc=${rpc}"
           - "--metadata=${metadata}"
+          % if request_payload_size > 0:
           - "--request_payload_size=${request_payload_size}"
+          % endif
+          % if response_payload_size > 0:
           - "--response_payload_size=${response_payload_size}"
+          % endif
           - "--print_response=${print_response}"
           % if enable_csm_observability:
           - "--enable_csm_observability"

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -41,6 +41,8 @@ spec:
           - "--qps=${qps}"
           - "--rpc=${rpc}"
           - "--metadata=${metadata}"
+          - "--request_payload_size=${request_payload_size}"
+          - "--response_payload_size=${response_payload_size}"
           - "--print_response=${print_response}"
           % if enable_csm_observability:
           - "--enable_csm_observability"

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -55,7 +55,9 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
 
         with self.subTest("2_start_test_client"):
             test_client: _XdsTestClient = self.startTestClient(
-                test_server, enable_csm_observability=True
+                test_server, enable_csm_observability=True,
+                request_payload_size=271828,
+                response_payload_size=314159,
             )
 
         with self.subTest("3_test_server_received_rpcs_from_test_client"):

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -55,7 +55,8 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
 
         with self.subTest("2_start_test_client"):
             test_client: _XdsTestClient = self.startTestClient(
-                test_server, enable_csm_observability=True,
+                test_server,
+                enable_csm_observability=True,
                 request_payload_size=271828,
                 response_payload_size=314159,
             )


### PR DESCRIPTION
Currently, the xds interop client is sending an empty payload for the `UnaryCall` rpc. Since testing CSM Observability will need a non-trivial payload (e.g. to verify the metrics about the number of bytes being sent), this PR will try to add 2 parameters `request_payload_size` and `response_payload_size` to the client image to control the size of the payload to be sent. Each language will need to implement this parameter in their respective client image. The one for c++ is [here](https://github.com/grpc/grpc/pull/35545).

Note that we only need to set these 2 parameters (both `request` and `resposne` payload size) on the _client deployment_ because the client will in turn tell the server how much to send back.

The good 'ol interop client already has these: https://github.com/grpc/grpc/blob/master/test/cpp/interop/interop_client.cc#L249-L251