### PR TITLE
Make test failure messages/tracebacks unique to PSM Interop

### DIFF
--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -22,7 +22,8 @@ from absl.testing import absltest
 
 class BaseTestCase(absltest.TestCase):
     def run(self, result: Optional[unittest.TestResult] = None) -> None:
-        super().run(result)
+        # TODO(sergiitk): should this method be returning result? See
+        #   super().run and xds_k8s_testcase.XdsKubernetesBaseTestCase.subTest
         test_errors = [error for test, error in result.errors if test is self]
         test_failures = [
             failure for test, failure in result.failures if test is self
@@ -36,8 +37,11 @@ class BaseTestCase(absltest.TestCase):
         )
         # Assume one test case will only have one status.
         if test_errors or test_failures:
+            total_errors = len(test_errors) + len(test_failures)
             logging.error(
-                "----- PSM Test Case FAILED: %s -----", self.test_name
+                "----- PSM Test Case FAILED: %s%s -----",
+                self.test_name,
+                f" | Errors count: {total_errors}" if total_errors > 1 else "",
             )
             if test_errors:
                 self._print_error_list(test_errors, is_unexpected_error=True)

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -77,9 +77,10 @@ class BaseTestCase(absltest.TestCase):
         for err in errors:
             logging.error(
                 "(%(fail_type)s) PSM Interop Test Failed: %(test_id)s"
-                "\n%(test_id)s | PSM Failed Test Traceback BEGIN"
-                "\n\n%(error)s"
-                "\n%(test_id)s | PSM Failed Test Traceback END\n",
+                "\n^^^^^"
+                "\n[%(test_id)s] PSM Failed Test Traceback BEGIN"
+                "\n%(error)s"
+                "[%(test_id)s] PSM Failed Test Traceback END\n",
                 {
                     "test_id": self.test_name,
                     "fail_type": fail_type,

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -36,21 +36,30 @@ class BaseTestCase(absltest.TestCase):
         )
         # Assume one test case will only have one status.
         if test_errors or test_failures:
-            logging.error("----- TestCase %s FAILED -----", self.test_name)
+            logging.error(
+                "----- PSM Test Case FAILED: %s -----", self.test_name
+            )
             if test_errors:
                 self._print_error_list(test_errors, is_unexpected_error=True)
             if test_failures:
                 self._print_error_list(test_failures)
         elif test_unexpected_successes:
             logging.error(
-                "----- TestCase %s UNEXPECTEDLY SUCCEEDED -----\n",
+                "----- PSM Test Case UNEXPECTEDLY SUCCEEDED: %s -----\n",
                 self.test_name,
             )
         elif test_skipped:
-            logging.info("----- TestCase %s SKIPPED -----\n", self.test_name)
-            logging.info("Reason for skipping: %s", test_skipped)
+            logging.info(
+                "----- PSM Test Case SKIPPED: %s -----"
+                "\nReason for skipping: %s",
+                self.test_name,
+                test_skipped,
+            )
         else:
-            logging.info("----- TestCase %s PASSED -----\n", self.test_name)
+            logging.info(
+                "----- PSM Test Case PASSED: %s -----\n",
+                self.test_name,
+            )
 
     @property
     def test_name(self) -> str:

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -68,18 +68,21 @@ class BaseTestCase(absltest.TestCase):
 
     @property
     def test_name(self) -> str:
-        # Test id returned from self.id() can have two forms:
-        # 1. Regular:       __main__.MyClassTest.test_method
-        # 2. Parametrized:  __main__.MyClassTest.test_method{case} ('param'),
-        #    where {case} is
-        #    a) An integer for @parameterized.parameters: test_method0,
-        #       test_method1, ...
-        #    b) {testcase_name} for @parameterized.named_parameters:
-        #       test_method_pass, test_method_fail, ...
-        #
-        # This method:
-        # 1. Removes "__main__." if it's present
-        # 2. Removes the " ('param')" if present
+        """Pretty test name (details in the description).
+
+        Test id returned from self.id() can have two forms:
+        1. Regular:       __main__.MyClassTest.test_method
+        2. Parametrized:  __main__.MyClassTest.test_method{case} ('param'),
+           where {case} is
+           a) An integer for @parameterized.parameters: test_method0,
+              test_method1, ...
+           b) {testcase_name} for @parameterized.named_parameters:
+              test_method_pass, test_method_fail, ...
+
+        This method:
+        1. Removes "__main__." if it's present
+        2. Removes the " ('param')" if present
+        """
         return self.id().removeprefix("__main__.").split(" ", 1)[0]
 
     def _print_error_list(

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -58,7 +58,8 @@ class BaseTestCase(absltest.TestCase):
         # the TestCase.assert*() methods.
         for err in errors:
             logging.error(
-                "%s Traceback in %s:\n%s",
+                "%s PSM Interop test failed: %s. PSM Traceback BEGIN \n%s"
+                "\nPSM Traceback END",
                 "ERROR" if is_unexpected_error else "FAILURE",
                 self.id(),
                 err,

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -36,13 +36,13 @@ class BaseTestCase(absltest.TestCase):
         )
         # Assume one test case will only have one status.
         if test_errors or test_failures:
-            logging.info("----- TestCase %s FAILED -----", self.test_name)
+            logging.error("----- TestCase %s FAILED -----", self.test_name)
             if test_errors:
                 self._print_error_list(test_errors, is_unexpected_error=True)
             if test_failures:
                 self._print_error_list(test_failures)
         elif test_unexpected_successes:
-            logging.info(
+            logging.error(
                 "----- TestCase %s UNEXPECTEDLY SUCCEEDED -----\n",
                 self.test_name,
             )

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -22,6 +22,7 @@ from absl.testing import absltest
 
 class BaseTestCase(absltest.TestCase):
     def run(self, result: Optional[unittest.TestResult] = None) -> None:
+        super().run(result)
         # TODO(sergiitk): should this method be returning result? See
         #   super().run and xds_k8s_testcase.XdsKubernetesBaseTestCase.subTest
         test_errors = [error for test, error in result.errors if test is self]

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -252,6 +252,7 @@ class XdsKubernetesBaseTestCase(base_testcase.BaseTestCase):
     def handle_sigint(
         self, signalnum: _SignalNum, frame: Optional[FrameType]
     ) -> None:
+        # TODO(sergiitk): move to base_testcase.BaseTestCase
         logger.info("Caught Ctrl+C, cleaning up...")
         self._handling_sigint = True
         # Force resource cleanup by their name. Addresses the case where ctrl-c
@@ -266,12 +267,18 @@ class XdsKubernetesBaseTestCase(base_testcase.BaseTestCase):
 
     @contextlib.contextmanager
     def subTest(self, msg, **params):  # noqa pylint: disable=signature-differs
-        logger.info("--- Starting subTest %s.%s ---", self.id(), msg)
+        # TODO(sergiitk): move to base_testcase.BaseTestCase
+        # Important side-effect: this halts test execution on first subtest
+        # failure, even if failfast is enabled.
+        # TODO(sergiitk): This is desired, but not understood. Figure out why.
+        logger.info("--- Starting subTest %s.%s ---", self.test_name, msg)
         try:
             yield super().subTest(msg, **params)
         finally:
             if not self._handling_sigint:
-                logger.info("--- Finished subTest %s.%s ---", self.id(), msg)
+                logger.info(
+                    "--- Finished subTest %s.%s ---", self.test_name, msg
+                )
 
     def setupTrafficDirectorGrpc(self):
         self.td.setup_for_grpc(
@@ -684,7 +691,7 @@ class IsolatedXdsKubernetesTestCase(
         raise NotImplementedError
 
     def tearDown(self):
-        logger.info("----- TestMethod %s teardown -----", self.id())
+        logger.info("----- TestMethod %s teardown -----", self.test_name)
         logger.debug("Getting pods restart times")
         client_restarts: int = 0
         server_restarts: int = 0

--- a/tests/bootstrap_generator_test.py
+++ b/tests/bootstrap_generator_test.py
@@ -130,7 +130,7 @@ class BootstrapGeneratorClientTest(
         super().tearDownClass()
 
     def tearDown(self):
-        logger.info("----- TestMethod %s teardown -----", self.id())
+        logger.info("----- TestMethod %s teardown -----", self.test_name)
         retryer = retryers.constant_retryer(
             wait_fixed=_timedelta(seconds=10),
             attempts=3,
@@ -175,7 +175,7 @@ class BootstrapGeneratorServerTest(
     test_server: XdsTestServer
 
     def tearDown(self):
-        logger.info("----- TestMethod %s teardown -----", self.id())
+        logger.info("----- TestMethod %s teardown -----", self.test_name)
         retryer = retryers.constant_retryer(
             wait_fixed=_timedelta(seconds=10),
             attempts=3,

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -46,7 +46,7 @@ class FakeTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
         self.assertTrue(True, "I'm a passing test at the end")
 
 
-class FakeTestParametrized(
+class FakeParametrizedTest(
     xds_k8s_testcase.XdsKubernetesBaseTestCase,
     parameterized.TestCase,
 ):
@@ -60,6 +60,15 @@ class FakeTestParametrized(
     )
     def test_true_named(self, is_true):
         self.assertTrue(is_true)
+
+
+class FakeSubtestTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
+    # TODO(sergiitk): add subtest examples
+    def test_even(self):
+        for num in range(0, 6):
+            with self.subTest(i=num, msg=f"num_{num}"):
+                if num & 1:
+                    self.fail(f"Integer {num} is odd")
 
 
 if __name__ == "__main__":

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -24,7 +24,7 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 
 
 class FakeTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
-    """A fake test with known failures to debug BaseTestCase logs.
+    """A fake test class with known failures to debug BaseTestCase logs.
 
     This test case won't do any infra provisioning, just parses the flags and
     reads k8s contexts file.
@@ -50,6 +50,11 @@ class FakeParametrizedTest(
     xds_k8s_testcase.XdsKubernetesBaseTestCase,
     parameterized.TestCase,
 ):
+    """A fake class to debug BaseTestCase logs produced by parametrized tests.
+
+    See FakeTest for notes on provisioning.
+    """
+
     @parameterized.parameters(True, False)
     def test_true(self, is_true):
         self.assertTrue(is_true)
@@ -63,7 +68,11 @@ class FakeParametrizedTest(
 
 
 class FakeSubtestTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
-    # TODO(sergiitk): add subtest examples
+    """A fake class to debug BaseTestCase logs produced by tests with subtests.
+
+    See FakeTest for notes on provisioning.
+    """
+
     def test_even(self):
         for num in range(0, 6):
             with self.subTest(i=num, msg=f"num_{num}"):

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -1,0 +1,66 @@
+# Copyright 2024 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from absl import flags
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from framework import xds_k8s_testcase
+
+logger = logging.getLogger(__name__)
+flags.adopt_module_key_flags(xds_k8s_testcase)
+
+
+class FakeTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
+    """A fake test with known failures to debug BaseTestCase logs.
+
+    This test case won't do any infra provisioning, just parses the flags and
+    reads k8s contexts file.
+    """
+
+    def test_0_pass(self):
+        self.assertTrue(True, "I'm a passing test in the beginning")
+
+    def test_1_error(self):
+        self.assertTrue(False, msg="Test 1 Assertion ERROR")
+
+    def test_2_pass(self):
+        self.assertTrue(True, "I'm a passing test in the middle")
+
+    def test_3_failure(self):
+        raise RuntimeError("Test 3 Uncaught Exception FAILURE")
+
+    def test_4_pass(self):
+        self.assertTrue(True, "I'm a passing test at the end")
+
+
+class FakeTestParametrized(
+    xds_k8s_testcase.XdsKubernetesBaseTestCase,
+    parameterized.TestCase,
+):
+    @parameterized.parameters(True, False)
+    def test_true(self, is_true):
+        self.assertTrue(is_true)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "pass", "is_true": True},
+        {"testcase_name": "fail", "is_true": False},
+    )
+    def test_true_named(self, is_true):
+        self.assertTrue(is_true)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
This PR:
- Make test failure messages/tracebacks unique to PSM Interop to allow for easier grepping/matchers (more details below.
- Replaces `self.id()` calls in the framework logs with custom `self.test_name`. For example,
  `--- Starting subTest __main__.AppNetTest.test_ping_pong.0_create_health_check ---`
  becomes
  `--- Starting subTest AppNetTest.test_ping_pong.0_create_health_check ---`.
- Changes the log level of `----- TestCase ... FAILED -----` message from `info` to `error`.
- Adds `FakeTest` to make future work on the log messages easier 
 
The new error format:
```
E0118 09:59:38.289015 140704433060736 base_testcase.py:39] ----- PSM Test Case FAILED: ClassName.test_method -----
E0118 09:59:38.289084 140704433060736 base_testcase.py:87] ($failure_type) PSM Interop Test Failed: ClassName.test_method
^^^^^
[ClassName.test_method] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
...
AssertionError: description
[ClassName.test_method] PSM Failed Test Traceback END
```

This format will allow us to drastically simplify buggrep matchers that search within the stack traces of _our_ framework, which also resulted in a test failure (e.g. didn't recover after retrying).
Now we can do a plain-text grep for `PSM Failed Test Traceback BEGIN` instead of an extended regex grep for `E[0-9]{4}.*base_testcase.*ERROR Traceback in`.
Text `PSM Failed Test Traceback BEGIN` is guaranteed to be only produced on test failure. Additionally, this allows to restrict matchers to a specific test in the same swoop, just do a plain-text search for `[TestClass.test_method] PSM Failed Test Traceback BEGIN`.

Initial PR that added the traceback: grpc/grpc#34023.

#### Examples
<details>
<summary>Click here for log examples</summary>

##### Regular
```
❯ ./run.sh tests/fake_test.py FakeTest
Running tests under Python 3.9.18: /Users/sergiitk/Development/psm-interop/venv/bin/python
I0118 09:59:38.165148 140704433060736 xds_k8s_testcase.py:157] ----- Testing FakeTest -----
I0118 09:59:38.165239 140704433060736 xds_k8s_testcase.py:158] Logs timezone: PST
I0118 09:59:38.165450 140704433060736 xds_k8s_testcase.py:106] Detected language and version: TestConfig(client_lang='cpp', server_lang='cpp', version=None)
I0118 09:59:38.278228 140704433060736 k8s.py:243] Using kubernetes context "gke_sergiitk-grpc-gke_us-west1-a_sergii-gamma", active host: https://34.83.62.236
[ RUN      ] FakeTest.test_0_pass
[       OK ] FakeTest.test_0_pass
I0118 09:59:38.288280 140704433060736 base_testcase.py:59] ----- PSM Test Case PASSED: FakeTest.test_0_pass -----

[ RUN      ] FakeTest.test_1_error
[  FAILED  ] FakeTest.test_1_error
E0118 09:59:38.289015 140704433060736 base_testcase.py:39] ----- PSM Test Case FAILED: FakeTest.test_1_error -----
E0118 09:59:38.289084 140704433060736 base_testcase.py:87] (FAILURE) PSM Interop Test Failed: FakeTest.test_1_error
^^^^^
[FakeTest.test_1_error] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 37, in test_1_error
    self.assertTrue(False, msg="Test 1 Assertion ERROR")
AssertionError: False is not true : Test 1 Assertion ERROR
[FakeTest.test_1_error] PSM Failed Test Traceback END

[ RUN      ] FakeTest.test_2_pass
[       OK ] FakeTest.test_2_pass
I0118 09:59:38.289330 140704433060736 base_testcase.py:59] ----- PSM Test Case PASSED: FakeTest.test_2_pass -----

[ RUN      ] FakeTest.test_3_failure
[  FAILED  ] FakeTest.test_3_failure
E0118 09:59:38.289599 140704433060736 base_testcase.py:39] ----- PSM Test Case FAILED: FakeTest.test_3_failure -----
E0118 09:59:38.289654 140704433060736 base_testcase.py:87] (ERROR) PSM Interop Test Failed: FakeTest.test_3_failure
^^^^^
[FakeTest.test_3_failure] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 43, in test_3_failure
    raise RuntimeError("Test 3 Uncaught Exception FAILURE")
RuntimeError: Test 3 Uncaught Exception FAILURE
[FakeTest.test_3_failure] PSM Failed Test Traceback END

[ RUN      ] FakeTest.test_4_pass
[       OK ] FakeTest.test_4_pass
I0118 09:59:38.289771 140704433060736 base_testcase.py:59] ----- PSM Test Case PASSED: FakeTest.test_4_pass -----
...
```

##### Parametrized

```
❯ ./run.sh tests/fake_test.py FakeTestParametrized
Running tests under Python 3.9.18: /Users/sergiitk/Development/psm-interop/venv/bin/python
I0118 10:01:10.861198 140704433060736 xds_k8s_testcase.py:157] ----- Testing FakeTestParametrized -----
I0118 10:01:10.861293 140704433060736 xds_k8s_testcase.py:158] Logs timezone: PST
I0118 10:01:10.861488 140704433060736 xds_k8s_testcase.py:106] Detected language and version: TestConfig(client_lang='cpp', server_lang='cpp', version=None)
I0118 10:01:10.967642 140704433060736 k8s.py:243] Using kubernetes context "gke_sergiitk-grpc-gke_us-west1-a_sergii-gamma", active host: https://34.83.62.236
[ RUN      ] FakeTestParametrized.test_true0 (True)
[       OK ] FakeTestParametrized.test_true0 (True)
I0118 10:01:10.975589 140704433060736 base_testcase.py:59] ----- PSM Test Case PASSED: FakeTestParametrized.test_true0 -----

[ RUN      ] FakeTestParametrized.test_true1 (False)
[  FAILED  ] FakeTestParametrized.test_true1 (False)
E0118 10:01:10.977038 140704433060736 base_testcase.py:39] ----- PSM Test Case FAILED: FakeTestParametrized.test_true1 -----
E0118 10:01:10.977118 140704433060736 base_testcase.py:87] (FAILURE) PSM Interop Test Failed: FakeTestParametrized.test_true1
^^^^^
[FakeTestParametrized.test_true1] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/absl/testing/parameterized.py", line 318, in bound_param_test
    return test_method(self, testcase_params)
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 55, in test_true
    self.assertTrue(is_true)
AssertionError: False is not true
[FakeTestParametrized.test_true1] PSM Failed Test Traceback END

[ RUN      ] FakeTestParametrized.test_true_named_fail
[  FAILED  ] FakeTestParametrized.test_true_named_fail
E0118 10:01:10.977355 140704433060736 base_testcase.py:39] ----- PSM Test Case FAILED: FakeTestParametrized.test_true_named_fail -----
E0118 10:01:10.977529 140704433060736 base_testcase.py:87] (FAILURE) PSM Interop Test Failed: FakeTestParametrized.test_true_named_fail
^^^^^
[FakeTestParametrized.test_true_named_fail] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/absl/testing/parameterized.py", line 314, in bound_param_test
    return test_method(self, **testcase_params)
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 62, in test_true_named
    self.assertTrue(is_true)
AssertionError: False is not true
[FakeTestParametrized.test_true_named_fail] PSM Failed Test Traceback END

[ RUN      ] FakeTestParametrized.test_true_named_pass
[       OK ] FakeTestParametrized.test_true_named_pass
I0118 10:01:10.977713 140704433060736 base_testcase.py:59] ----- PSM Test Case PASSED: FakeTestParametrized.test_true_named_pass -----

...
```

##### Multiple errors attached to a single test (faked):

```
...
[ RUN      ] FakeTest.test_3_failure
[  FAILED  ] FakeTest.test_3_failure
E0118 10:12:54.482913 140704433060736 base_testcase.py:43] ----- PSM Test Case FAILED: FakeTest.test_3_failure | Errors count: 2 -----
E0118 10:12:54.482974 140704433060736 base_testcase.py:93] (ERROR) PSM Interop Test Failed: FakeTest.test_3_failure
^^^^^
[FakeTest.test_3_failure] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 43, in test_3_failure
    raise RuntimeError("Test 3 Uncaught Exception FAILURE")
RuntimeError: Test 3 Uncaught Exception FAILURE
[FakeTest.test_3_failure] PSM Failed Test Traceback END

E0118 10:12:54.483037 140704433060736 base_testcase.py:93] (FAILURE) PSM Interop Test Failed: FakeTest.test_3_failure
^^^^^
[FakeTest.test_3_failure] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 43, in test_3_failure
    raise RuntimeError("Test 3 Uncaught Exception FAILURE")
RuntimeError: Test 3 Uncaught Exception FAILURE
[FakeTest.test_3_failure] PSM Failed Test Traceback END

[ RUN      ] FakeTest.test_4_pass
...
```

</details>
