### PR TITLE
Add google-cloud-monitoring client library support

### DIFF
--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 
 from absl import flags
 from google.cloud import secretmanager_v1
+import google.cloud.monitoring_v3
 from google.longrunning import operations_pb2
 from google.protobuf import json_format
 from google.rpc import code_pb2
@@ -174,6 +175,26 @@ class GcpApiManager:
             return secretmanager_v1.SecretManagerServiceClient()
 
         raise NotImplementedError(f"Secret Manager {version} not supported")
+
+    @functools.lru_cache(None)
+    def monitoring_metric_service(self, version: str):
+        """Monitoring API Metric Service.
+
+        Manages metric descriptors, monitored resource descriptors,
+        and time series data.
+
+        https://cloud.google.com/python/docs/reference/monitoring/latest/google.cloud.monitoring_v3.services.metric_service.MetricServiceClient
+        """
+        client = None
+        if version == "v3":
+            # TODO(sergiitk): set client_options arg is staging api is needed.
+            client = google.cloud.monitoring_v3.MetricServiceClient()
+
+        if not client:
+            raise NotImplementedError(f"Metric Service {version} not supported")
+
+        self._exit_stack.enter_context(client)
+        return client
 
     @functools.lru_cache(None)
     def iam(self, version: str) -> discovery.Resource:

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -187,7 +187,7 @@ class GcpApiManager:
         """
         client = None
         if version == "v3":
-            # TODO(sergiitk): set client_options arg is staging api is needed.
+            # TODO(sergiitk): set client_options arg if staging api is needed.
             client = google.cloud.monitoring_v3.MetricServiceClient()
 
         if not client:

--- a/requirements.lock
+++ b/requirements.lock
@@ -3,6 +3,7 @@ PyYAML==6.0
 absl-py==0.15.0
 google-api-python-client==1.12.11
 google-cloud-secret-manager==2.15.1
+google-cloud-monitoring==2.18.0
 grpcio==1.57.0
 grpcio-health-checking==1.57.0
 grpcio-tools==1.57.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ PyYAML~=6.0
 absl-py~=0.11
 google-api-python-client~=1.12
 google-cloud-secret-manager~=2.1
+google-cloud-monitoring~=2.18
 grpcio~=1.57
 grpcio-health-checking~=1.57
 grpcio-tools~=1.57


### PR DESCRIPTION
- Include `google-cloud-monitoring~=2.18` into the requirements
- Add cached `GcpApiManager.monitoring_metric_service` method returning self-closing `google.cloud.monitoring_v3.MetricServiceClient`
- Add a placeholder subtest `gamma.csm_observability_test.4_check_monitoring_metric_client` that checks the monitoring API connection by making an RPC with intentionally incorrect server-validated argument, and expecting an `InvalidArgument` response from the server.