### PR TITLE
Add assertions to CSM Observability Test

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -44,6 +44,8 @@ class GammaServerRunner(KubernetesServerRunner):
 
     route_name: str
     frontend_service_name: str
+    csm_workload_name: str
+    csm_canonical_service_name: str
 
     def __init__(
         self,
@@ -75,6 +77,8 @@ class GammaServerRunner(KubernetesServerRunner):
         bepolicy_name: str = "backend-policy",
         termination_grace_period_seconds: int = 0,
         pre_stop_hook: bool = False,
+        csm_workload_name: str = "",
+        csm_canonical_service_name: str = "",
     ):
         # pylint: disable=too-many-locals
         super().__init__(
@@ -107,6 +111,8 @@ class GammaServerRunner(KubernetesServerRunner):
         self.bepolicy_name = bepolicy_name
         self.termination_grace_period_seconds = termination_grace_period_seconds
         self.pre_stop_hook = pre_stop_hook
+        self.csm_workload_name = csm_workload_name
+        self.csm_canonical_service_name = csm_canonical_service_name
 
     def run(  # pylint: disable=arguments-differ
         self,
@@ -120,8 +126,6 @@ class GammaServerRunner(KubernetesServerRunner):
         route_template: str = "gamma/route_http.yaml",
         enable_csm_observability: bool = False,
         generate_mesh_id: bool = False,
-        csm_workload_name: str = "",
-        csm_canonical_service_name: str = "",
     ) -> List[XdsTestServer]:
         if not maintenance_port:
             maintenance_port = self._get_default_maintenance_port(secure_mode)
@@ -208,8 +212,8 @@ class GammaServerRunner(KubernetesServerRunner):
             pre_stop_hook=self.pre_stop_hook,
             enable_csm_observability=enable_csm_observability,
             generate_mesh_id=generate_mesh_id,
-            csm_workload_name=csm_workload_name,
-            csm_canonical_service_name=csm_canonical_service_name,
+            csm_workload_name=self.csm_workload_name,
+            csm_canonical_service_name=self.csm_canonical_service_name,
         )
 
         # Create a PodMonitoring resource if CSM Observability is enabled

--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -94,7 +94,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             # permission to use GCP service account identity.
             self.gcp_iam = gcp.iam.IamV1(gcp_api_manager, gcp_project)
 
-    def run(  # pylint: disable=arguments-differ
+    def run(  # pylint: disable=arguments-differ,too-many-locals
         self,
         *,
         server_target,
@@ -109,6 +109,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
         enable_csm_observability: bool = False,
         request_payload_size: int = 0,
         response_payload_size: int = 0,
+        csm_workload_name: str = "",
+        csm_canonical_service_name: str = "",
     ) -> XdsTestClient:
         logger.info(
             (
@@ -166,6 +168,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             generate_mesh_id=generate_mesh_id,
             print_response=print_response,
             enable_csm_observability=enable_csm_observability,
+            csm_workload_name=csm_workload_name,
+            csm_canonical_service_name=csm_canonical_service_name,
         )
 
         # Create a PodMonitoring resource if CSM Observability is enabled

--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -34,6 +34,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
     debug_use_port_forwarding: bool
     td_bootstrap_image: str
     network: str
+    csm_workload_name: str
+    csm_canonical_service_name: str
 
     # Optional fields.
     service_account_name: Optional[str] = None
@@ -62,6 +64,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
         namespace_template: Optional[str] = None,
         debug_use_port_forwarding: bool = False,
         enable_workload_identity: bool = True,
+        csm_workload_name: str = "",
+        csm_canonical_service_name: str = "",
     ):
         super().__init__(
             k8s_namespace,
@@ -79,6 +83,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
         self.deployment_template = deployment_template
         self.enable_workload_identity = enable_workload_identity
         self.debug_use_port_forwarding = debug_use_port_forwarding
+        self.csm_workload_name = csm_workload_name
+        self.csm_canonical_service_name = csm_canonical_service_name
 
         # Used by the TD bootstrap generator.
         self.td_bootstrap_image = td_bootstrap_image
@@ -109,8 +115,6 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
         enable_csm_observability: bool = False,
         request_payload_size: int = 0,
         response_payload_size: int = 0,
-        csm_workload_name: str = "",
-        csm_canonical_service_name: str = "",
     ) -> XdsTestClient:
         logger.info(
             (
@@ -168,8 +172,8 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             generate_mesh_id=generate_mesh_id,
             print_response=print_response,
             enable_csm_observability=enable_csm_observability,
-            csm_workload_name=csm_workload_name,
-            csm_canonical_service_name=csm_canonical_service_name,
+            csm_workload_name=self.csm_workload_name,
+            csm_canonical_service_name=self.csm_canonical_service_name,
         )
 
         # Create a PodMonitoring resource if CSM Observability is enabled

--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -100,7 +100,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             # permission to use GCP service account identity.
             self.gcp_iam = gcp.iam.IamV1(gcp_api_manager, gcp_project)
 
-    def run(  # pylint: disable=arguments-differ,too-many-locals
+    def run(  # pylint: disable=arguments-differ
         self,
         *,
         server_target,

--- a/framework/xds_gamma_testcase.py
+++ b/framework/xds_gamma_testcase.py
@@ -94,7 +94,7 @@ class GammaXdsKubernetesTestCase(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             compute_api_version=self.compute_api_version,
         )
 
-    def initKubernetesServerRunner(self) -> GammaServerRunner:
+    def initKubernetesServerRunner(self, **kwargs) -> GammaServerRunner:
         return GammaServerRunner(
             k8s.KubernetesNamespace(
                 self.k8s_api_manager, self.server_namespace
@@ -112,6 +112,7 @@ class GammaXdsKubernetesTestCase(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             enable_workload_identity=self.enable_workload_identity,
             termination_grace_period_seconds=self.termination_grace_period_seconds,
             pre_stop_hook=self.pre_stop_hook,
+            **kwargs,
         )
 
     def startTestClient(

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -812,7 +812,7 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             enable_workload_identity=self.enable_workload_identity,
         )
 
-    def initKubernetesClientRunner(self) -> KubernetesClientRunner:
+    def initKubernetesClientRunner(self, **kwargs) -> KubernetesClientRunner:
         return KubernetesClientRunner(
             k8s.KubernetesNamespace(
                 self.k8s_api_manager, self.client_namespace
@@ -829,6 +829,7 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             enable_workload_identity=self.enable_workload_identity,
             stats_port=self.client_port,
             reuse_namespace=self.server_namespace == self.client_namespace,
+            **kwargs,
         )
 
     def startTestServers(

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -906,7 +906,7 @@ class SecurityXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             compute_api_version=self.compute_api_version,
         )
 
-    def initKubernetesServerRunner(self) -> KubernetesServerRunner:
+    def initKubernetesServerRunner(self, **kwargs) -> KubernetesServerRunner:
         return KubernetesServerRunner(
             k8s.KubernetesNamespace(
                 self.k8s_api_manager, self.server_namespace
@@ -921,9 +921,10 @@ class SecurityXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             xds_server_uri=self.xds_server_uri,
             deployment_template="server-secure.deployment.yaml",
             debug_use_port_forwarding=self.debug_use_port_forwarding,
+            **kwargs,
         )
 
-    def initKubernetesClientRunner(self) -> KubernetesClientRunner:
+    def initKubernetesClientRunner(self, **kwargs) -> KubernetesClientRunner:
         return KubernetesClientRunner(
             k8s.KubernetesNamespace(
                 self.k8s_api_manager, self.client_namespace
@@ -940,6 +941,7 @@ class SecurityXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             stats_port=self.client_port,
             reuse_namespace=self.server_namespace == self.client_namespace,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
+            **kwargs,
         )
 
     def startSecureTestServer(self, replica_count=1, **kwargs) -> XdsTestServer:

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -683,11 +683,11 @@ class IsolatedXdsKubernetesTestCase(
         raise NotImplementedError
 
     @abc.abstractmethod
-    def initKubernetesServerRunner(self) -> KubernetesServerRunner:
+    def initKubernetesServerRunner(self, **kwargs) -> KubernetesServerRunner:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def initKubernetesClientRunner(self) -> KubernetesClientRunner:
+    def initKubernetesClientRunner(self, **kwargs) -> KubernetesClientRunner:
         raise NotImplementedError
 
     def tearDown(self):
@@ -795,7 +795,7 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             compute_api_version=self.compute_api_version,
         )
 
-    def initKubernetesServerRunner(self) -> KubernetesServerRunner:
+    def initKubernetesServerRunner(self, **kwargs) -> KubernetesServerRunner:
         return KubernetesServerRunner(
             k8s.KubernetesNamespace(
                 self.k8s_api_manager, self.server_namespace
@@ -810,6 +810,7 @@ class RegularXdsKubernetesTestCase(IsolatedXdsKubernetesTestCase):
             network=self.network,
             debug_use_port_forwarding=self.debug_use_port_forwarding,
             enable_workload_identity=self.enable_workload_identity,
+            **kwargs,
         )
 
     def initKubernetesClientRunner(self, **kwargs) -> KubernetesClientRunner:

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -66,6 +66,22 @@ spec:
             value: "true"
           - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
             value: "true"
+          % if enable_csm_observability:
+          - name: CSM_WORKLOAD_NAME
+            value: ${csm_workload_name}
+          - name: CSM_CANONICAL_SERVICE_NAME
+            value: ${csm_canonical_service_name}
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NAMESPACE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+          % endif
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -74,6 +74,7 @@ spec:
           - name: CSM_CANONICAL_SERVICE_NAME
             value: ${csm_canonical_service_name}
           % endif
+          % if enable_csm_observability:
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -84,6 +85,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+          % endif
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -66,11 +66,14 @@ spec:
             value: "true"
           - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
             value: "true"
-          % if enable_csm_observability:
+          % if csm_workload_name:
           - name: CSM_WORKLOAD_NAME
             value: ${csm_workload_name}
+          % endif
+          % if csm_canonical_service_name:
           - name: CSM_CANONICAL_SERVICE_NAME
             value: ${csm_canonical_service_name}
+          % endif
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -81,7 +84,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
-          % endif
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -60,6 +60,7 @@ spec:
           - name: CSM_CANONICAL_SERVICE_NAME
             value: ${csm_canonical_service_name}
           % endif
+          % if enable_csm_observability:
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -70,6 +71,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+          % endif
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -52,6 +52,22 @@ spec:
             value: "true"
           - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
             value: "true"
+          % if enable_csm_observability:
+          - name: CSM_WORKLOAD_NAME
+            value: ${csm_workload_name}
+          - name: CSM_CANONICAL_SERVICE_NAME
+            value: ${csm_canonical_service_name}
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NAMESPACE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: OTEL_RESOURCE_ATTRIBUTES
+            value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+          % endif
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -52,11 +52,14 @@ spec:
             value: "true"
           - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
             value: "true"
-          % if enable_csm_observability:
+          % if csm_workload_name:
           - name: CSM_WORKLOAD_NAME
             value: ${csm_workload_name}
+          % endif
+          % if csm_canonical_service_name:
           - name: CSM_CANONICAL_SERVICE_NAME
             value: ${csm_canonical_service_name}
+          % endif
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -67,7 +70,6 @@ spec:
                 fieldPath: metadata.namespace
           - name: OTEL_RESOURCE_ATTRIBUTES
             value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
-          % endif
         volumeMounts:
           - mountPath: /tmp/grpc-xds/
             name: grpc-td-conf

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -125,10 +125,11 @@ class MetricTimeSeries:
             points=list(response.points),
         )
 
-    def pretty_print(self):
+    def pretty_print(self) -> str:
         metric = dataclasses.asdict(self)
+        # too much noise to print all data points from a time series
         metric.pop("points")
-        logger.info(yaml.dump(metric, sort_keys=True))
+        return yaml.dump(metric, sort_keys=True)
 
 
 class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
@@ -218,7 +219,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             metric_time_series = MetricTimeSeries.from_response(
                 metric, time_series[0]
             )
-            metric_time_series.pretty_print()
+            logger.info(metric_time_series.pretty_print())
             results[metric] = metric_time_series
         return results
 

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -20,65 +20,83 @@ from google.api_core import exceptions as gapi_errors
 from google.cloud import monitoring_v3
 
 from framework import xds_gamma_testcase
-from framework import xds_k8s_flags
 from framework import xds_k8s_testcase
 from framework.helpers import skips
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)
 
+# Type aliases
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _Lang = skips.Lang
 
 # Testing consts
-_TEST_RUN_SECS = 90
-_REQUEST_PAYLOAD_SIZE = 271828
-_RESPONSE_PAYLOAD_SIZE = 314159
-_GRPC_METHOD_NAME = "grpc.testing.TestService/UnaryCall"
-_CSM_WORKLOAD_NAME_SERVER = "csm_workload_name_from_server"
-_CSM_WORKLOAD_NAME_CLIENT = "csm_workload_name_from_client"
-_CSM_CANONICAL_SERVICE_NAME_SERVER = "csm_canonical_service_name_from_server"
-_CSM_CANONICAL_SERVICE_NAME_CLIENT = "csm_canonical_service_name_from_client"
-_METRIC_CLIENT_ATTEMPT_SENT = "prometheus.googleapis.com/grpc_client_attempt_sent_total_compressed_message_size_bytes/histogram"
-_METRIC_CLIENT_ATTEMPT_RCVD = "prometheus.googleapis.com/grpc_client_attempt_rcvd_total_compressed_message_size_bytes/histogram"
-_METRIC_CLIENT_ATTEMPT_DURATION = (
-    "prometheus.googleapis.com/grpc_client_attempt_duration_seconds/histogram"
+TEST_RUN_SECS = 90
+REQUEST_PAYLOAD_SIZE = 271828
+RESPONSE_PAYLOAD_SIZE = 314159
+VALUE_NOT_CHECKED = object()  # Sentinel value
+GRPC_METHOD_NAME = "grpc.testing.TestService/UnaryCall"
+CSM_WORKLOAD_NAME_SERVER = "csm_workload_name_from_server"
+CSM_WORKLOAD_NAME_CLIENT = "csm_workload_name_from_client"
+CSM_CANONICAL_SERVICE_NAME_SERVER = "csm_canonical_service_name_from_server"
+CSM_CANONICAL_SERVICE_NAME_CLIENT = "csm_canonical_service_name_from_client"
+PROMETHEUS_HOST = "prometheus.googleapis.com"
+METRIC_CLIENT_ATTEMPT_SENT = (
+    f"{PROMETHEUS_HOST}/"
+    "grpc_client_attempt_sent_total_compressed_message_size_bytes/histogram"
 )
-_METRIC_CLIENT_ATTEMPT_STARTED = (
-    "prometheus.googleapis.com/grpc_client_attempt_started_total/counter"
+METRIC_CLIENT_ATTEMPT_RCVD = (
+    f"{PROMETHEUS_HOST}/"
+    "grpc_client_attempt_rcvd_total_compressed_message_size_bytes/histogram"
 )
-_METRIC_SERVER_CALL_RCVD = "prometheus.googleapis.com/grpc_server_call_rcvd_total_compressed_message_size_bytes/histogram"
-_METRIC_SERVER_CALL_SENT = "prometheus.googleapis.com/grpc_server_call_sent_total_compressed_message_size_bytes/histogram"
-_METRIC_SERVER_CALL_DURATION = (
-    "prometheus.googleapis.com/grpc_server_call_duration_seconds/histogram"
+METRIC_CLIENT_ATTEMPT_DURATION = (
+    f"{PROMETHEUS_HOST}/grpc_client_attempt_duration_seconds/histogram"
 )
-_METRIC_SERVER_CALL_STARTED = (
-    "prometheus.googleapis.com/grpc_server_call_started_total/counter"
+METRIC_CLIENT_ATTEMPT_STARTED = (
+    f"{PROMETHEUS_HOST}/grpc_client_attempt_started_total/counter"
 )
-_HISTOGRAM_CLIENT_METRICS = [
-    _METRIC_CLIENT_ATTEMPT_SENT,
-    _METRIC_CLIENT_ATTEMPT_RCVD,
-    _METRIC_CLIENT_ATTEMPT_DURATION,
+METRIC_SERVER_CALL_RCVD = (
+    f"{PROMETHEUS_HOST}/"
+    "grpc_server_call_rcvd_total_compressed_message_size_bytes/histogram"
+)
+METRIC_SERVER_CALL_SENT = (
+    f"{PROMETHEUS_HOST}/"
+    "grpc_server_call_sent_total_compressed_message_size_bytes/histogram"
+)
+METRIC_SERVER_CALL_DURATION = (
+    f"{PROMETHEUS_HOST}/grpc_server_call_duration_seconds/histogram"
+)
+METRIC_SERVER_CALL_STARTED = (
+    f"{PROMETHEUS_HOST}/grpc_server_call_started_total/counter"
+)
+HISTOGRAM_CLIENT_METRICS = [
+    METRIC_CLIENT_ATTEMPT_SENT,
+    METRIC_CLIENT_ATTEMPT_RCVD,
+    METRIC_CLIENT_ATTEMPT_DURATION,
 ]
-_HISTOGRAM_SERVER_METRICS = [
-    _METRIC_SERVER_CALL_DURATION,
-    _METRIC_SERVER_CALL_RCVD,
-    _METRIC_SERVER_CALL_SENT,
+HISTOGRAM_SERVER_METRICS = [
+    METRIC_SERVER_CALL_DURATION,
+    METRIC_SERVER_CALL_RCVD,
+    METRIC_SERVER_CALL_SENT,
 ]
-_COUNTER_CLIENT_METRICS = [
-    _METRIC_CLIENT_ATTEMPT_STARTED,
+COUNTER_CLIENT_METRICS = [
+    METRIC_CLIENT_ATTEMPT_STARTED,
 ]
-_COUNTER_SERVER_METRICS = [
-    _METRIC_SERVER_CALL_STARTED,
+COUNTER_SERVER_METRICS = [
+    METRIC_SERVER_CALL_STARTED,
 ]
-_HISTOGRAM_METRICS = _HISTOGRAM_CLIENT_METRICS + _HISTOGRAM_SERVER_METRICS
-_COUNTER_METRICS = _COUNTER_CLIENT_METRICS + _COUNTER_SERVER_METRICS
-_ALL_METRICS = _HISTOGRAM_METRICS + _COUNTER_METRICS
+HISTOGRAM_METRICS = HISTOGRAM_CLIENT_METRICS + HISTOGRAM_SERVER_METRICS
+COUNTER_METRICS = COUNTER_CLIENT_METRICS + COUNTER_SERVER_METRICS
+CLIENT_METRICS = HISTOGRAM_CLIENT_METRICS + COUNTER_CLIENT_METRICS
+SERVER_METRICS = HISTOGRAM_SERVER_METRICS + COUNTER_SERVER_METRICS
+ALL_METRICS = HISTOGRAM_METRICS + COUNTER_METRICS
 
 
 class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     metric_client: monitoring_v3.MetricServiceClient
+    test_server: _XdsTestServer
+    test_client: _XdsTestClient
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
@@ -92,89 +110,105 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         super().setUpClass()
         cls.metric_client = cls.gcp_api_manager.monitoring_metric_service("v3")
 
+    # query filter string to be passed to the Monitoring API
+    def build_filter_str(self, filter_str_template, replacements):
+        return filter_str_template % replacements
+
     # A helper function to make the cloud monitoring API call to query metrics
     # created by this test run.
-    def _query_metrics(self, metric_names, filter_str, interval):
+    def query_metrics(self, metric_names, filter_str_template, interval):
         results = {}
+        metric_log_lines = []
         for metric in metric_names:
             response = self.metric_client.list_time_series(
                 name=f"projects/{self.project}",
-                filter=filter_str
-                % {
-                    "metric": metric,
-                    "grpc_method": _GRPC_METHOD_NAME,
-                },
+                filter=self.build_filter_str(
+                    filter_str_template,
+                    {
+                        "metric": metric,
+                        "grpc_method": GRPC_METHOD_NAME,
+                    },
+                ),
                 interval=interval,
                 view=monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
             )
             time_series = []
-            logger.debug("Metric: %s", metric)
+            metric_log_lines.append(f"Metric: {metric}")
             for series in response:
-                logger.debug(" Metric Labels:")
+                metric_log_lines.append(" Metric Labels:")
                 for label_key, label_value in series.metric.labels.items():
-                    logger.debug(
-                        "  %(label_key)s: %(label_value)s",
-                        {
-                            "label_key": label_key,
-                            "label_value": label_value,
-                        },
-                    )
-                logger.debug(" Resource Labels:")
+                    metric_log_lines.append(f"  {label_key}: {label_value}")
+                metric_log_lines.append(" Resource Labels:")
                 for label_key, label_value in series.resource.labels.items():
-                    logger.debug(
-                        "  %(label_key)s: %(label_value)s",
-                        {
-                            "label_key": label_key,
-                            "label_value": label_value,
-                        },
-                    )
+                    metric_log_lines.append(f"  {label_key}: {label_value}")
                 time_series.append(series)
             results[metric] = time_series
+        logger.info("\n".join(metric_log_lines))
         return results
 
     # A helper function to check whether at least one of the "points" whose
     # mean should be within 5% of ref_bytes.
-    def _at_least_one_point_within_range(self, points, ref_bytes) -> bool:
+    def assertAtLeastOnePointWithinRange(self, points, ref_bytes):
         for point in points:
             if point.value.distribution_value.mean > (
                 ref_bytes * 0.95
             ) and point.value.distribution_value.mean < (ref_bytes * 1.05):
-                return True
-        return False
+                return
+        self.fail(f"No data point with ~{ref_bytes} bytes found")
 
-    def _is_server_metric(self, metric_name) -> bool:
-        return "server" in metric_name
+    # 1. actual_labels must have all the keys in expected_labels
+    #
+    # 2. actual_labels must have all the correct key: value pairs
+    #    in expected_labels unless the expected value is
+    #    VALUE_NOT_CHECKED
+    #
+    # 3. actual_labels may have extra keys that we don't care about
+    def assertExpectedLabels(self, expected_labels, actual_labels):
+        # Test whether actual_labels contains all the keys that we are
+        # expected
+        for label_key in expected_labels.keys():
+            self.assertIn(label_key, actual_labels)
 
-    def _is_client_metric(self, metric_name) -> bool:
-        return "client" in metric_name
+        # Test the label values against the expected dict
+        # Ignore those keys that were marked VALUE_NOT_CHECKED
+        self.assertDictEqual(
+            {
+                key: value
+                for key, value in expected_labels.items()
+                if value != VALUE_NOT_CHECKED
+            },
+            {
+                key: actual_labels[key]
+                for key, value in expected_labels.items()
+                if value != VALUE_NOT_CHECKED
+            },
+        )
 
     def test_csm_observability(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma
         #   resource creation out of self.startTestServers()
         with self.subTest("1_run_test_server"):
             start_secs = int(time.time())
-            test_server: _XdsTestServer = self.startTestServers(
+            self.test_server = self.startTestServers(
                 enable_csm_observability=True,
-                csm_workload_name=_CSM_WORKLOAD_NAME_SERVER,
-                csm_canonical_service_name=_CSM_CANONICAL_SERVICE_NAME_SERVER,
+                csm_workload_name=CSM_WORKLOAD_NAME_SERVER,
+                csm_canonical_service_name=CSM_CANONICAL_SERVICE_NAME_SERVER,
             )[0]
 
         with self.subTest("2_start_test_client"):
-            test_client: _XdsTestClient = self.startTestClient(
-                test_server,
+            self.test_client = self.startTestClient(
+                self.test_server,
                 enable_csm_observability=True,
-                request_payload_size=_REQUEST_PAYLOAD_SIZE,
-                response_payload_size=_RESPONSE_PAYLOAD_SIZE,
-                csm_workload_name=_CSM_WORKLOAD_NAME_CLIENT,
-                csm_canonical_service_name=_CSM_CANONICAL_SERVICE_NAME_CLIENT,
+                request_payload_size=REQUEST_PAYLOAD_SIZE,
+                response_payload_size=RESPONSE_PAYLOAD_SIZE,
+                csm_workload_name=CSM_WORKLOAD_NAME_CLIENT,
+                csm_canonical_service_name=CSM_CANONICAL_SERVICE_NAME_CLIENT,
             )
-            logger.info(
-                "Letting test client run for %d seconds", _TEST_RUN_SECS
-            )
-            time.sleep(_TEST_RUN_SECS)
+            logger.info("Letting test client run for %d seconds", TEST_RUN_SECS)
+            time.sleep(TEST_RUN_SECS)
 
         with self.subTest("3_test_server_received_rpcs_from_test_client"):
-            self.assertSuccessfulRpcs(test_client)
+            self.assertSuccessfulRpcs(self.test_client)
 
         with self.subTest("4_query_monitoring_metric_client"):
             end_secs = int(time.time())
@@ -196,278 +230,147 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             # The 'grpc_method' filter condition is needed because the
             # server metrics are also serving on the Channelz requests.
             #
-            filter_str = (
+            filter_str_template = (
                 'metric.type = "%(metric)s" AND '
                 'metric.labels.grpc_status = "OK" AND '
                 'metric.labels.grpc_method = "%(grpc_method)s"'
             )
-            histogram_results = self._query_metrics(
-                _HISTOGRAM_METRICS, filter_str, interval
+            histogram_results = self.query_metrics(
+                HISTOGRAM_METRICS, filter_str_template, interval
             )
 
             # The num rpcs started counter metrics do not have the
             # 'grpc_status' label
-            filter_str = (
+            filter_str_template = (
                 'metric.type = "%(metric)s" AND '
                 'metric.labels.grpc_method = "%(grpc_method)s"'
             )
-            counter_results = self._query_metrics(
-                _COUNTER_METRICS, filter_str, interval
+            counter_results = self.query_metrics(
+                COUNTER_METRICS, filter_str_template, interval
             )
 
             all_results = {**histogram_results, **counter_results}
+            self.assertNotEmpty(all_results, msg="No query metrics results")
 
         with self.subTest("5_check_metrics_time_series"):
-            for metric, time_series in all_results.items():
+            for metric in ALL_METRICS:
+                # Every metric needs to exist in the query results
+                self.assertIn(metric, all_results)
+
+                time_series = all_results[metric]
                 # There should be exactly 1 time series per metric with these
                 # label value combinations that we are expecting.
                 self.assertEqual(1, len(time_series))
 
-        # Testing whether each metric has the right set of metric label keys
-        with self.subTest("6_check_metrics_label_keys"):
-            for metric in _HISTOGRAM_CLIENT_METRICS:
-                metric_labels = all_results[metric][0].metric.labels
-                for label_key in [
-                    "csm_mesh_id",
-                    "csm_remote_workload_canonical_service",
-                    "csm_remote_workload_cluster_name",
-                    "csm_remote_workload_location",
-                    "csm_remote_workload_name",
-                    "csm_remote_workload_namespace_name",
-                    "csm_remote_workload_project_id",
-                    "csm_remote_workload_type",
-                    "csm_service_name",
-                    "csm_service_namespace_name",
-                    "csm_workload_canonical_service",
-                    "grpc_method",
-                    "grpc_status",
-                    "grpc_target",
-                ]:
-                    self.assertIn(label_key, metric_labels)
+        # Testing whether each metric has the correct set of metric keys and
+        # values
+        with self.subTest("6_check_metrics_labels"):
+            for metric in ALL_METRICS:
+                if metric in HISTOGRAM_CLIENT_METRICS:
+                    expected_metric_labels = {
+                        "csm_mesh_id": VALUE_NOT_CHECKED,
+                        "csm_remote_workload_canonical_service": CSM_CANONICAL_SERVICE_NAME_SERVER,
+                        "csm_remote_workload_cluster_name": VALUE_NOT_CHECKED,
+                        "csm_remote_workload_location": VALUE_NOT_CHECKED,
+                        "csm_remote_workload_name": CSM_WORKLOAD_NAME_SERVER,
+                        "csm_remote_workload_namespace_name": self.server_namespace,
+                        "csm_remote_workload_project_id": self.project,
+                        "csm_remote_workload_type": "gcp_kubernetes_engine",
+                        "csm_service_name": self.server_runner.service_name,
+                        "csm_service_namespace_name": self.server_namespace,
+                        "csm_workload_canonical_service": CSM_CANONICAL_SERVICE_NAME_CLIENT,
+                        "grpc_method": GRPC_METHOD_NAME,
+                        "grpc_status": VALUE_NOT_CHECKED,
+                        "grpc_target": VALUE_NOT_CHECKED,
+                        "pod": self.test_client.hostname,
+                    }
+                elif metric in HISTOGRAM_SERVER_METRICS:
+                    expected_metric_labels = {
+                        "csm_mesh_id": VALUE_NOT_CHECKED,
+                        "csm_remote_workload_canonical_service": CSM_CANONICAL_SERVICE_NAME_CLIENT,
+                        "csm_remote_workload_cluster_name": VALUE_NOT_CHECKED,
+                        "csm_remote_workload_location": VALUE_NOT_CHECKED,
+                        "csm_remote_workload_name": CSM_WORKLOAD_NAME_CLIENT,
+                        "csm_remote_workload_namespace_name": self.client_namespace,
+                        "csm_remote_workload_project_id": self.project,
+                        "csm_remote_workload_type": "gcp_kubernetes_engine",
+                        "csm_workload_canonical_service": CSM_CANONICAL_SERVICE_NAME_SERVER,
+                        "grpc_method": GRPC_METHOD_NAME,
+                        "grpc_status": VALUE_NOT_CHECKED,
+                        "pod": self.test_server.hostname,
+                    }
+                elif metric in COUNTER_CLIENT_METRICS:
+                    expected_metric_labels = {
+                        "grpc_method": GRPC_METHOD_NAME,
+                        "grpc_target": VALUE_NOT_CHECKED,
+                        "pod": self.test_client.hostname,
+                    }
+                elif metric in COUNTER_SERVER_METRICS:
+                    expected_metric_labels = {
+                        "grpc_method": GRPC_METHOD_NAME,
+                        "pod": self.test_server.hostname,
+                    }
+                else:
+                    self.fail(f"Unknown metric: {metric}")
 
-            for metric in _HISTOGRAM_SERVER_METRICS:
-                metric_labels = all_results[metric][0].metric.labels
-                for label_key in [
-                    "csm_mesh_id",
-                    "csm_remote_workload_canonical_service",
-                    "csm_remote_workload_cluster_name",
-                    "csm_remote_workload_location",
-                    "csm_remote_workload_name",
-                    "csm_remote_workload_namespace_name",
-                    "csm_remote_workload_project_id",
-                    "csm_remote_workload_type",
-                    "csm_workload_canonical_service",
-                    "grpc_method",
-                    "grpc_status",
-                ]:
-                    self.assertIn(label_key, metric_labels)
-
-            for metric in _COUNTER_CLIENT_METRICS:
-                metric_labels = all_results[metric][0].metric.labels
-                for label_key in [
-                    "grpc_method",
-                    "grpc_target",
-                ]:
-                    self.assertIn(label_key, metric_labels)
-
-            for metric in _COUNTER_SERVER_METRICS:
-                metric_labels = all_results[metric][0].metric.labels
-                for label_key in [
-                    "grpc_method",
-                ]:
-                    self.assertIn(label_key, metric_labels)
+                actual_metric_labels = all_results[metric][0].metric.labels
+                self.assertExpectedLabels(
+                    expected_metric_labels, actual_metric_labels
+                )
 
         # Testing whether each metric has the right set of monitored resource
-        # label keys
-        with self.subTest("7_check_resource_label_keys"):
-            # all metrics should have the same set of monitored resource labels
-            # which come from the GMP job
-            for metric in _ALL_METRICS:
-                resource_labels = all_results[metric][0].resource.labels
-                for label_key in [
-                    "cluster",
-                    "instance",
-                    "job",
-                    "location",
-                    "namespace",
-                    "project_id",
-                ]:
-                    self.assertIn(label_key, resource_labels)
+        # label keys and values
+        with self.subTest("7_check_resource_labels"):
+            for metric in ALL_METRICS:
+                time_series = all_results[metric][0]
+                self.assertEqual("prometheus_target", time_series.resource.type)
 
-        # Testing the values of metric labels
-        with self.subTest("8_check_metrics_label_values"):
-            for metric, time_series in all_results.items():
-                series = time_series[0]
-                self.assertEqual(metric, series.metric.type)
-                for label_key, label_value in series.metric.labels.items():
-                    if label_key == "pod" and self._is_client_metric(metric):
-                        # client pod name
-                        self.assertEqual(test_client.hostname, label_value)
-                    elif label_key == "pod" and self._is_server_metric(metric):
-                        # server pod name
-                        self.assertEqual(test_server.hostname, label_value)
-                    elif label_key == "grpc_method":
-                        self.assertEqual(_GRPC_METHOD_NAME, label_value)
-                    elif label_key == "grpc_target":
-                        # server namespace should be somewhere in the xds
-                        # server target
-                        self.assertIn(self.server_namespace, label_value)
-                    elif (
-                        label_key == "csm_remote_workload_canonical_service"
-                        and self._is_client_metric(metric)
-                    ):
-                        # the remote workload canonical service name
-                        # for the client is the one we set in the server
-                        self.assertEqual(
-                            _CSM_CANONICAL_SERVICE_NAME_SERVER, label_value
-                        )
-                    elif (
-                        label_key == "csm_remote_workload_canonical_service"
-                        and self._is_server_metric(metric)
-                    ):
-                        # the remote workload canonical service name
-                        # for the server is the one we set in the client
-                        self.assertEqual(
-                            _CSM_CANONICAL_SERVICE_NAME_CLIENT, label_value
-                        )
-                    elif label_key == "csm_remote_workload_cluster_name":
-                        # the cluster name should be somewhere in the
-                        # kube context
-                        self.assertIn(
-                            label_value, xds_k8s_flags.KUBE_CONTEXT.value
-                        )
-                    elif label_key == "csm_remote_workload_location":
-                        # the location should be somewhere in the kube context
-                        self.assertIn(
-                            label_value, xds_k8s_flags.KUBE_CONTEXT.value
-                        )
-                    elif (
-                        label_key == "csm_remote_workload_name"
-                        and self._is_client_metric(metric)
-                    ):
-                        # the remote workload name for the client is the name
-                        # we set on the server
-                        self.assertEqual(_CSM_WORKLOAD_NAME_SERVER, label_value)
-                    elif (
-                        label_key == "csm_remote_workload_name"
-                        and self._is_server_metric(metric)
-                    ):
-                        # the remote workload name for the server is the name
-                        # we set on the client
-                        self.assertEqual(_CSM_WORKLOAD_NAME_CLIENT, label_value)
-                    elif (
-                        label_key == "csm_remote_workload_namespace_name"
-                        and self._is_client_metric(metric)
-                    ):
-                        # the server namespace name
-                        self.assertEqual(self.server_namespace, label_value)
-                    elif (
-                        label_key == "csm_remote_workload_namespace_name"
-                        and self._is_server_metric(metric)
-                    ):
-                        # the client namespace name
-                        self.assertEqual(self.client_namespace, label_value)
-                    elif label_key == "csm_remote_workload_project_id":
-                        self.assertEqual(self.project, label_value)
-                    elif label_key == "csm_remote_workload_type":
-                        # a hardcoded value
-                        self.assertEqual("gcp_kubernetes_engine", label_value)
-                    elif label_key == "csm_service_name":
-                        # the service name
-                        self.assertEqual(
-                            self.server_runner.service_name, label_value
-                        )
-                    elif label_key == "csm_service_namespace_name":
-                        # the server namespace name
-                        self.assertEqual(self.server_namespace, label_value)
-                    elif (
-                        label_key == "csm_workload_canonical_service"
-                        and self._is_client_metric(metric)
-                    ):
-                        # the client workload canonical service name
-                        self.assertEqual(
-                            _CSM_CANONICAL_SERVICE_NAME_CLIENT, label_value
-                        )
-                    elif (
-                        label_key == "csm_workload_canonical_service"
-                        and self._is_server_metric(metric)
-                    ):
-                        # the server workload canonical service name
-                        self.assertEqual(
-                            _CSM_CANONICAL_SERVICE_NAME_SERVER, label_value
-                        )
+                # all metrics should have the same set of monitored resource labels
+                # keys, which come from the GMP job
+                if metric in CLIENT_METRICS:
+                    expected_resource_labels = {
+                        "cluster": VALUE_NOT_CHECKED,
+                        "instance": VALUE_NOT_CHECKED,
+                        "job": self.client_runner.pod_monitoring_name,
+                        "location": VALUE_NOT_CHECKED,
+                        "namespace": self.client_namespace,
+                        "project_id": self.project,
+                    }
+                elif metric in SERVER_METRICS:
+                    expected_resource_labels = {
+                        "cluster": VALUE_NOT_CHECKED,
+                        "instance": VALUE_NOT_CHECKED,
+                        "job": self.server_runner.pod_monitoring_name,
+                        "location": VALUE_NOT_CHECKED,
+                        "namespace": self.server_namespace,
+                        "project_id": self.project,
+                    }
+                else:
+                    self.fail(f"Unexpected metric: {metric}")
 
-        # Testing the values of monitored resource labels
-        with self.subTest("9_check_resource_label_values"):
-            for metric, time_series in all_results.items():
-                series = time_series[0]
-                self.assertEqual("prometheus_target", series.resource.type)
-                for label_key, label_value in series.resource.labels.items():
-                    if label_key == "project_id":
-                        self.assertEqual(self.project, label_value)
-                    elif label_key == "namespace" and self._is_client_metric(
-                        metric
-                    ):
-                        # client namespace
-                        self.assertEqual(self.client_namespace, label_value)
-                    elif label_key == "namespace" and self._is_server_metric(
-                        metric
-                    ):
-                        # server namespace
-                        self.assertEqual(self.server_namespace, label_value)
-                    elif label_key == "job" and self._is_client_metric(metric):
-                        # the "job" label on the monitored resource refers to
-                        # the GMP PodMonitoring resource name
-                        self.assertEqual(
-                            self.client_runner.pod_monitoring_name,
-                            label_value,
-                        )
-                    elif label_key == "job" and self._is_server_metric(metric):
-                        # the "job" label on the monitored resource refers to
-                        # the GMP PodMonitoring resource name
-                        self.assertEqual(
-                            self.server_runner.pod_monitoring_name,
-                            label_value,
-                        )
-                    elif label_key == "cluster":
-                        self.assertIn(
-                            label_value, xds_k8s_flags.KUBE_CONTEXT.value
-                        )
-                    elif label_key == "instance" and self._is_client_metric(
-                        metric
-                    ):
-                        # the "instance" label on the monitored resource refers
-                        # to the GKE pod and port
-                        self.assertIn(test_client.hostname, label_value)
-                    elif label_key == "instance" and self._is_server_metric(
-                        metric
-                    ):
-                        # the "instance" label on the monitored resource refers
-                        # to the GKE pod and port
-                        self.assertIn(test_server.hostname, label_value)
+                actual_resource_labels = time_series.resource.labels
+                self.assertExpectedLabels(
+                    expected_resource_labels, actual_resource_labels
+                )
 
         # This tests whether each of the "byes sent" histogram type metric
         # should have at least 1 data point whose mean should converge to be
         # close to the number of bytes being sent by the RPCs.
-        with self.subTest("10_check_bytes_sent_vs_data_points"):
+        with self.subTest("8_check_bytes_sent_vs_data_points"):
             for metric in [
-                _METRIC_CLIENT_ATTEMPT_SENT,
-                _METRIC_SERVER_CALL_RCVD,
+                METRIC_CLIENT_ATTEMPT_SENT,
+                METRIC_SERVER_CALL_RCVD,
             ]:
-                self.assertTrue(
-                    self._at_least_one_point_within_range(
-                        all_results[metric][0].points, _REQUEST_PAYLOAD_SIZE
-                    )
+                self.assertAtLeastOnePointWithinRange(
+                    all_results[metric][0].points, REQUEST_PAYLOAD_SIZE
                 )
 
             for metric in [
-                _METRIC_CLIENT_ATTEMPT_RCVD,
-                _METRIC_SERVER_CALL_SENT,
+                METRIC_CLIENT_ATTEMPT_RCVD,
+                METRIC_SERVER_CALL_SENT,
             ]:
-                self.assertTrue(
-                    self._at_least_one_point_within_range(
-                        all_results[metric][0].points, _RESPONSE_PAYLOAD_SIZE
-                    )
+                self.assertAtLeastOnePointWithinRange(
+                    all_results[metric][0].points, RESPONSE_PAYLOAD_SIZE
                 )
 
 

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -156,14 +156,14 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         #   resource creation out of self.startTestServers()
         with self.subTest("1_run_test_server"):
             start_secs = int(time.time())
-            test_server = self.startTestServers(
+            test_server: _XdsTestServer = self.startTestServers(
                 enable_csm_observability=True,
                 csm_workload_name=CSM_WORKLOAD_NAME_SERVER,
                 csm_canonical_service_name=CSM_CANONICAL_SERVICE_NAME_SERVER,
             )[0]
 
         with self.subTest("2_start_test_client"):
-            test_client = self.startTestClient(
+            test_client: _XdsTestClient = self.startTestClient(
                 test_server,
                 enable_csm_observability=True,
                 request_payload_size=REQUEST_PAYLOAD_SIZE,

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -225,7 +225,10 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     # A helper function to check whether at least one of the "points" whose
     # mean should be within 5% of ref_bytes.
     def assertAtLeastOnePointWithinRange(
-        self, points, ref_bytes, tolerance: float = 0.05
+        self,
+        points: list[monitoring_v3.types.Point],
+        ref_bytes: int,
+        tolerance: float = 0.05,
     ):
         for point in points:
             if (

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -238,11 +238,14 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 view=monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
             )
             time_series = list(response)
-            if len(time_series) != 1:
-                self.fail(
-                    f"Query for {metric} should return exactly 1 time series. "
-                    f"Found {len(time_series)}."
-                )
+
+            self.assertLen(
+                time_series,
+                1,
+                msg=f"Query for {metric} should return exactly 1 time series."
+                f" Found {len(time_series)}.",
+            )
+
             metric_time_series = MetricTimeSeries.from_response(
                 metric, time_series[0]
             )
@@ -268,13 +271,16 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 request_payload_size=REQUEST_PAYLOAD_SIZE,
                 response_payload_size=RESPONSE_PAYLOAD_SIZE,
             )
-            logger.info("Letting test client run for %d seconds", TEST_RUN_SECS)
-            time.sleep(TEST_RUN_SECS)
 
         with self.subTest("3_test_server_received_rpcs_from_test_client"):
             self.assertSuccessfulRpcs(test_client)
 
         with self.subTest("4_query_cloud_monitoring_metrics"):
+            logger.info(
+                "Letting test client run for %d seconds to produce metric data",
+                TEST_RUN_SECS,
+            )
+            time.sleep(TEST_RUN_SECS)
             end_secs = int(time.time())
             interval = monitoring_v3.TimeInterval(
                 start_time={"seconds": start_secs},

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import time
 
 from absl import flags
 from absl.testing import absltest
@@ -19,6 +20,7 @@ from google.api_core import exceptions as gapi_errors
 from google.cloud import monitoring_v3
 
 from framework import xds_gamma_testcase
+from framework import xds_k8s_flags
 from framework import xds_k8s_testcase
 from framework.helpers import skips
 
@@ -28,6 +30,59 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _Lang = skips.Lang
+
+# Testing consts
+_TEST_RUN_SECS = 90
+_REQUEST_PAYLOAD_SIZE = 271828
+_RESPONSE_PAYLOAD_SIZE = 314159
+_GRPC_METHOD_NAME = "grpc.testing.TestService/UnaryCall"
+_CSM_WORKLOAD_NAME_SERVER = "csm_workload_name_from_server"
+_CSM_WORKLOAD_NAME_CLIENT = "csm_workload_name_from_client"
+_CSM_CANONICAL_SERVICE_NAME_SERVER = "csm_canonical_service_name_from_server"
+_CSM_CANONICAL_SERVICE_NAME_CLIENT = "csm_canonical_service_name_from_client"
+_METRIC_CLIENT_ATTEMPT_SENT = "prometheus.googleapis.com/grpc_client_attempt_sent_total_compressed_message_size_bytes/histogram"
+_METRIC_CLIENT_ATTEMPT_RCVD = "prometheus.googleapis.com/grpc_client_attempt_rcvd_total_compressed_message_size_bytes/histogram"
+_METRIC_CLIENT_ATTEMPT_DURATION = (
+    "prometheus.googleapis.com/grpc_client_attempt_duration_seconds/histogram"
+)
+_METRIC_CLIENT_ATTEMPT_STARTED = (
+    "prometheus.googleapis.com/grpc_client_attempt_started_total/counter"
+)
+_METRIC_SERVER_CALL_RCVD = "prometheus.googleapis.com/grpc_server_call_rcvd_total_compressed_message_size_bytes/histogram"
+_METRIC_SERVER_CALL_SENT = "prometheus.googleapis.com/grpc_server_call_sent_total_compressed_message_size_bytes/histogram"
+_METRIC_SERVER_CALL_DURATION = (
+    "prometheus.googleapis.com/grpc_server_call_duration_seconds/histogram"
+)
+_METRIC_SERVER_CALL_STARTED = (
+    "prometheus.googleapis.com/grpc_server_call_started_total/counter"
+)
+_HISTOGRAM_CLIENT_METRICS = [
+    _METRIC_CLIENT_ATTEMPT_SENT,
+    _METRIC_CLIENT_ATTEMPT_RCVD,
+    _METRIC_CLIENT_ATTEMPT_DURATION,
+]
+_HISTOGRAM_SERVER_METRICS = [
+    _METRIC_SERVER_CALL_DURATION,
+    _METRIC_SERVER_CALL_RCVD,
+    _METRIC_SERVER_CALL_SENT,
+]
+_CLIENT_SENT_METRICS = [
+    _METRIC_CLIENT_ATTEMPT_SENT,
+    _METRIC_SERVER_CALL_RCVD,
+]
+_SERVER_SENT_METRICS = [
+    _METRIC_CLIENT_ATTEMPT_RCVD,
+    _METRIC_SERVER_CALL_SENT,
+]
+_COUNTER_CLIENT_METRICS = [
+    _METRIC_CLIENT_ATTEMPT_STARTED,
+]
+_COUNTER_SERVER_METRICS = [
+    _METRIC_SERVER_CALL_STARTED,
+]
+_HISTOGRAM_METRICS = _HISTOGRAM_CLIENT_METRICS + _HISTOGRAM_SERVER_METRICS
+_COUNTER_METRICS = _COUNTER_CLIENT_METRICS + _COUNTER_SERVER_METRICS
+_ALL_METRICS = _HISTOGRAM_METRICS + _COUNTER_METRICS
 
 
 class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
@@ -45,39 +100,389 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         super().setUpClass()
         cls.metric_client = cls.gcp_api_manager.monitoring_metric_service("v3")
 
+    # A helper function to make the cloud monitoring API call to query metrics
+    # created by this test run.
+    def _query_metrics(self, metric_names, filter_str, interval):
+        results = {}
+        for metric in metric_names:
+            response = self.metric_client.list_time_series(
+                name=f"projects/{self.project}",
+                filter=filter_str
+                % {
+                    "metric": metric,
+                    "grpc_method": _GRPC_METHOD_NAME,
+                },
+                interval=interval,
+                view=monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+            )
+            time_series = []
+            logger.debug("Metric: %s", metric)
+            for series in response:
+                logger.debug(" Metric Labels:")
+                for label_key, label_value in series.metric.labels.items():
+                    logger.debug(
+                        "  %(label_key)s: %(label_value)s",
+                        {
+                            "label_key": label_key,
+                            "label_value": label_value,
+                        },
+                    )
+                logger.debug(" Resource Labels:")
+                for label_key, label_value in series.resource.labels.items():
+                    logger.debug(
+                        "  %(label_key)s: %(label_value)s",
+                        {
+                            "label_key": label_key,
+                            "label_value": label_value,
+                        },
+                    )
+                time_series.append(series)
+            results[metric] = time_series
+        return results
+
+    # A helper function to check whether at least one of the "points" whose
+    # mean should be within 5% of ref_bytes.
+    def _at_least_one_point_within_range(self, points, ref_bytes) -> bool:
+        for point in points:
+            if point.value.distribution_value.mean > (
+                ref_bytes * 0.95
+            ) and point.value.distribution_value.mean < (ref_bytes * 1.05):
+                return True
+        return False
+
+    def _is_server_metric(self, metric_name) -> bool:
+        return "server" in metric_name
+
+    def _is_client_metric(self, metric_name) -> bool:
+        return "client" in metric_name
+
     def test_csm_observability(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma
         #   resource creation out of self.startTestServers()
         with self.subTest("1_run_test_server"):
+            start_secs = int(time.time())
             test_server: _XdsTestServer = self.startTestServers(
-                enable_csm_observability=True
+                enable_csm_observability=True,
+                csm_workload_name=_CSM_WORKLOAD_NAME_SERVER,
+                csm_canonical_service_name=_CSM_CANONICAL_SERVICE_NAME_SERVER,
             )[0]
 
         with self.subTest("2_start_test_client"):
             test_client: _XdsTestClient = self.startTestClient(
                 test_server,
                 enable_csm_observability=True,
-                request_payload_size=271828,
-                response_payload_size=314159,
+                request_payload_size=_REQUEST_PAYLOAD_SIZE,
+                response_payload_size=_RESPONSE_PAYLOAD_SIZE,
+                csm_workload_name=_CSM_WORKLOAD_NAME_CLIENT,
+                csm_canonical_service_name=_CSM_CANONICAL_SERVICE_NAME_CLIENT,
             )
+            logger.info(
+                "Letting test client run for %d seconds", _TEST_RUN_SECS
+            )
+            time.sleep(_TEST_RUN_SECS)
 
         with self.subTest("3_test_server_received_rpcs_from_test_client"):
             self.assertSuccessfulRpcs(test_client)
 
-        # For now, this just makes a bogus call to ensure metrics client
-        # connected to the remote API service.
-        with self.subTest("4_check_monitoring_metric_client"):
-            with self.assertRaises(gapi_errors.GoogleAPICallError) as cm:
-                self.metric_client.list_metric_descriptors(
-                    request=monitoring_v3.ListMetricDescriptorsRequest(
-                        name="whatever",
+        with self.subTest("4_query_monitoring_metric_client"):
+            end_secs = int(time.time())
+            interval = monitoring_v3.TimeInterval(
+                {
+                    "end_time": {"seconds": end_secs, "nanos": 0},
+                    "start_time": {"seconds": start_secs, "nanos": 0},
+                }
+            )
+            #
+            # The list_time_series API requires us to query one metric
+            # at a time.
+            #
+            # The 'grpc_status = "OK"' filter condition is needed because
+            # some time series data points were logged when the grpc_status
+            # was "UNAVAILABLE" when the client/server were establishing
+            # connections.
+            #
+            # The 'grpc_method' filter condition is needed because the
+            # server metrics are also serving on the Channelz requests.
+            #
+            filter_str = (
+                'metric.type = "%(metric)s" AND '
+                'metric.labels.grpc_status = "OK" AND '
+                'metric.labels.grpc_method = "%(grpc_method)s"'
+            )
+            histogram_results = self._query_metrics(
+                _HISTOGRAM_METRICS, filter_str, interval
+            )
+
+            # The num rpcs started counter metrics do not have the
+            # 'grpc_status' label
+            filter_str = (
+                'metric.type = "%(metric)s" AND '
+                'metric.labels.grpc_method = "%(grpc_method)s"'
+            )
+            counter_results = self._query_metrics(
+                _COUNTER_METRICS, filter_str, interval
+            )
+
+            all_results = {**histogram_results, **counter_results}
+
+        with self.subTest("5_check_metrics_time_series"):
+            for metric, time_series in all_results.items():
+                # There should be exactly 1 time series per metric with these
+                # label value combinations that we are expecting.
+                self.assertEqual(1, len(time_series))
+
+        # Testing whether each metric has the right set of metric label keys
+        with self.subTest("6_check_metrics_label_keys"):
+            for metric in _HISTOGRAM_CLIENT_METRICS:
+                metric_labels = all_results[metric][0].metric.labels
+                for label_key in [
+                    "csm_mesh_id",
+                    "csm_remote_workload_canonical_service",
+                    "csm_remote_workload_cluster_name",
+                    "csm_remote_workload_location",
+                    "csm_remote_workload_name",
+                    "csm_remote_workload_namespace_name",
+                    "csm_remote_workload_project_id",
+                    "csm_remote_workload_type",
+                    "csm_service_name",
+                    "csm_service_namespace_name",
+                    "csm_workload_canonical_service",
+                    "grpc_method",
+                    "grpc_status",
+                    "grpc_target",
+                    "otel_scope_name",
+                    "otel_scope_version",
+                    "pod",
+                ]:
+                    self.assertIn(label_key, metric_labels)
+
+            for metric in _HISTOGRAM_SERVER_METRICS:
+                metric_labels = all_results[metric][0].metric.labels
+                for label_key in [
+                    "csm_mesh_id",
+                    "csm_remote_workload_canonical_service",
+                    "csm_remote_workload_cluster_name",
+                    "csm_remote_workload_location",
+                    "csm_remote_workload_name",
+                    "csm_remote_workload_namespace_name",
+                    "csm_remote_workload_project_id",
+                    "csm_remote_workload_type",
+                    "csm_workload_canonical_service",
+                    "grpc_method",
+                    "grpc_status",
+                    "otel_scope_name",
+                    "otel_scope_version",
+                    "pod",
+                ]:
+                    self.assertIn(label_key, metric_labels)
+
+            for metric in _COUNTER_CLIENT_METRICS:
+                metric_labels = all_results[metric][0].metric.labels
+                for label_key in [
+                    "grpc_method",
+                    "grpc_target",
+                    "otel_scope_name",
+                    "otel_scope_version",
+                    "pod",
+                ]:
+                    self.assertIn(label_key, metric_labels)
+
+            for metric in _COUNTER_SERVER_METRICS:
+                metric_labels = all_results[metric][0].metric.labels
+                for label_key in [
+                    "grpc_method",
+                    "otel_scope_name",
+                    "otel_scope_version",
+                    "pod",
+                ]:
+                    self.assertIn(label_key, metric_labels)
+
+        # Testing whether each metric has the right set of monitored resource
+        # label keys
+        with self.subTest("7_check_resource_label_keys"):
+            # all metrics should have the same set of monitored resource labels
+            # which come from the GMP job
+            for metric in _ALL_METRICS:
+                resource_labels = all_results[metric][0].resource.labels
+                for label_key in [
+                    "cluster",
+                    "instance",
+                    "job",
+                    "location",
+                    "namespace",
+                    "project_id",
+                ]:
+                    self.assertIn(label_key, resource_labels)
+
+        # Testing the values of metric labels
+        with self.subTest("8_check_metrics_label_values"):
+            for metric, time_series in all_results.items():
+                series = time_series[0]
+                self.assertEqual(metric, series.metric.type)
+                for label_key, label_value in series.metric.labels.items():
+                    if label_key == "pod" and self._is_client_metric(metric):
+                        # client pod name
+                        self.assertEqual(test_client.hostname, label_value)
+                    elif label_key == "pod" and self._is_server_metric(metric):
+                        # server pod name
+                        self.assertEqual(test_server.hostname, label_value)
+                    elif label_key == "grpc_method":
+                        self.assertEqual(_GRPC_METHOD_NAME, label_value)
+                    elif label_key == "grpc_target":
+                        # server namespace should be somewhere in the xds
+                        # server target
+                        self.assertIn(self.server_namespace, label_value)
+                    elif (
+                        label_key == "csm_remote_workload_canonical_service"
+                        and self._is_client_metric(metric)
+                    ):
+                        # the remote workload canonical service name
+                        # for the client is the one we set in the server
+                        self.assertEqual(
+                            _CSM_CANONICAL_SERVICE_NAME_SERVER, label_value
+                        )
+                    elif (
+                        label_key == "csm_remote_workload_canonical_service"
+                        and self._is_server_metric(metric)
+                    ):
+                        # the remote workload canonical service name
+                        # for the server is the one we set in the client
+                        self.assertEqual(
+                            _CSM_CANONICAL_SERVICE_NAME_CLIENT, label_value
+                        )
+                    elif label_key == "csm_remote_workload_cluster_name":
+                        # the cluster name should be somewhere in the
+                        # kube context
+                        self.assertIn(
+                            label_value, xds_k8s_flags.KUBE_CONTEXT.value
+                        )
+                    elif label_key == "csm_remote_workload_location":
+                        # the location should be somewhere in the kube context
+                        self.assertIn(
+                            label_value, xds_k8s_flags.KUBE_CONTEXT.value
+                        )
+                    elif (
+                        label_key == "csm_remote_workload_name"
+                        and self._is_client_metric(metric)
+                    ):
+                        # the remote workload name for the client is the name
+                        # we set on the server
+                        self.assertEqual(_CSM_WORKLOAD_NAME_SERVER, label_value)
+                    elif (
+                        label_key == "csm_remote_workload_name"
+                        and self._is_server_metric(metric)
+                    ):
+                        # the remote workload name for the server is the name
+                        # we set on the client
+                        self.assertEqual(_CSM_WORKLOAD_NAME_CLIENT, label_value)
+                    elif (
+                        label_key == "csm_remote_workload_namespace_name"
+                        and self._is_client_metric(metric)
+                    ):
+                        # the server namespace name
+                        self.assertEqual(self.server_namespace, label_value)
+                    elif (
+                        label_key == "csm_remote_workload_namespace_name"
+                        and self._is_server_metric(metric)
+                    ):
+                        # the client namespace name
+                        self.assertEqual(self.client_namespace, label_value)
+                    elif label_key == "csm_remote_workload_project_id":
+                        self.assertEqual(self.project, label_value)
+                    elif label_key == "csm_remote_workload_type":
+                        # a hardcoded value
+                        self.assertEqual("gcp_kubernetes_engine", label_value)
+                    elif label_key == "csm_service_name":
+                        # the service name
+                        self.assertEqual(
+                            self.server_runner.service_name, label_value
+                        )
+                    elif label_key == "csm_service_namespace_name":
+                        # the server namespace name
+                        self.assertEqual(self.server_namespace, label_value)
+                    elif (
+                        label_key == "csm_workload_canonical_service"
+                        and self._is_client_metric(metric)
+                    ):
+                        # the client workload canonical service name
+                        self.assertEqual(
+                            _CSM_CANONICAL_SERVICE_NAME_CLIENT, label_value
+                        )
+                    elif (
+                        label_key == "csm_workload_canonical_service"
+                        and self._is_server_metric(metric)
+                    ):
+                        # the server workload canonical service name
+                        self.assertEqual(
+                            _CSM_CANONICAL_SERVICE_NAME_SERVER, label_value
+                        )
+
+        # Testing the values of monitored resource labels
+        with self.subTest("9_check_resource_label_values"):
+            for metric, time_series in all_results.items():
+                series = time_series[0]
+                self.assertEqual("prometheus_target", series.resource.type)
+                for label_key, label_value in series.resource.labels.items():
+                    if label_key == "project_id":
+                        self.assertEqual(self.project, label_value)
+                    elif label_key == "namespace" and self._is_client_metric(
+                        metric
+                    ):
+                        # client namespace
+                        self.assertEqual(self.client_namespace, label_value)
+                    elif label_key == "namespace" and self._is_server_metric(
+                        metric
+                    ):
+                        # server namespace
+                        self.assertEqual(self.server_namespace, label_value)
+                    elif label_key == "job" and self._is_client_metric(metric):
+                        # the "job" label on the monitored resource refers to
+                        # the GMP PodMonitoring resource name
+                        self.assertEqual(
+                            self.client_runner.pod_monitoring_name,
+                            label_value,
+                        )
+                    elif label_key == "job" and self._is_server_metric(metric):
+                        # the "job" label on the monitored resource refers to
+                        # the GMP PodMonitoring resource name
+                        self.assertEqual(
+                            self.server_runner.pod_monitoring_name,
+                            label_value,
+                        )
+                    elif label_key == "cluster":
+                        self.assertIn(
+                            label_value, xds_k8s_flags.KUBE_CONTEXT.value
+                        )
+                    elif label_key == "instance" and self._is_client_metric(
+                        metric
+                    ):
+                        # the "instance" label on the monitored resource refers
+                        # to the GKE pod and port
+                        self.assertIn(test_client.hostname, label_value)
+                    elif label_key == "instance" and self._is_server_metric(
+                        metric
+                    ):
+                        # the "instance" label on the monitored resource refers
+                        # to the GKE pod and port
+                        self.assertIn(test_server.hostname, label_value)
+
+        # This tests whether each of the "byes sent" histogram type metric
+        # should have at least 1 data point whose mean should converge to be
+        # close to the number of bytes being sent by the RPCs.
+        with self.subTest("10_check_bytes_sent_vs_data_points"):
+            for metric in _CLIENT_SENT_METRICS:
+                self.assertTrue(
+                    self._at_least_one_point_within_range(
+                        all_results[metric][0].points, _REQUEST_PAYLOAD_SIZE
                     )
                 )
-            err = cm.exception
-            self.assertIsInstance(err, gapi_errors.InvalidArgument)
-            self.assertIsNotNone(err.grpc_status_code)
-            self.assertStartsWith(err.message, "Name must begin with")
-            self.assertEndsWith(err.message, " got: whatever")
+
+            for metric in _SERVER_SENT_METRICS:
+                self.assertTrue(
+                    self._at_least_one_point_within_range(
+                        all_results[metric][0].points, _RESPONSE_PAYLOAD_SIZE
+                    )
+                )
 
 
 if __name__ == "__main__":

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -66,14 +66,6 @@ _HISTOGRAM_SERVER_METRICS = [
     _METRIC_SERVER_CALL_RCVD,
     _METRIC_SERVER_CALL_SENT,
 ]
-_CLIENT_SENT_METRICS = [
-    _METRIC_CLIENT_ATTEMPT_SENT,
-    _METRIC_SERVER_CALL_RCVD,
-]
-_SERVER_SENT_METRICS = [
-    _METRIC_CLIENT_ATTEMPT_RCVD,
-    _METRIC_SERVER_CALL_SENT,
-]
 _COUNTER_CLIENT_METRICS = [
     _METRIC_CLIENT_ATTEMPT_STARTED,
 ]
@@ -250,9 +242,6 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                     "grpc_method",
                     "grpc_status",
                     "grpc_target",
-                    "otel_scope_name",
-                    "otel_scope_version",
-                    "pod",
                 ]:
                     self.assertIn(label_key, metric_labels)
 
@@ -270,9 +259,6 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                     "csm_workload_canonical_service",
                     "grpc_method",
                     "grpc_status",
-                    "otel_scope_name",
-                    "otel_scope_version",
-                    "pod",
                 ]:
                     self.assertIn(label_key, metric_labels)
 
@@ -281,9 +267,6 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 for label_key in [
                     "grpc_method",
                     "grpc_target",
-                    "otel_scope_name",
-                    "otel_scope_version",
-                    "pod",
                 ]:
                     self.assertIn(label_key, metric_labels)
 
@@ -291,9 +274,6 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 metric_labels = all_results[metric][0].metric.labels
                 for label_key in [
                     "grpc_method",
-                    "otel_scope_name",
-                    "otel_scope_version",
-                    "pod",
                 ]:
                     self.assertIn(label_key, metric_labels)
 
@@ -470,14 +450,20 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         # should have at least 1 data point whose mean should converge to be
         # close to the number of bytes being sent by the RPCs.
         with self.subTest("10_check_bytes_sent_vs_data_points"):
-            for metric in _CLIENT_SENT_METRICS:
+            for metric in [
+                _METRIC_CLIENT_ATTEMPT_SENT,
+                _METRIC_SERVER_CALL_RCVD,
+            ]:
                 self.assertTrue(
                     self._at_least_one_point_within_range(
                         all_results[metric][0].points, _REQUEST_PAYLOAD_SIZE
                     )
                 )
 
-            for metric in _SERVER_SENT_METRICS:
+            for metric in [
+                _METRIC_CLIENT_ATTEMPT_RCVD,
+                _METRIC_SERVER_CALL_SENT,
+            ]:
                 self.assertTrue(
                     self._at_least_one_point_within_range(
                         all_results[metric][0].points, _RESPONSE_PAYLOAD_SIZE

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -118,16 +118,12 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     # created by this test run.
     def query_metrics(self, metric_names, filter_str_template, interval):
         results = {}
-        metric_log_lines = []
+        metric_log_lines = [""]
         for metric in metric_names:
             response = self.metric_client.list_time_series(
                 name=f"projects/{self.project}",
                 filter=self.build_filter_str(
-                    filter_str_template,
-                    {
-                        "metric": metric,
-                        "grpc_method": GRPC_METHOD_NAME,
-                    },
+                    filter_str_template, {"metric": metric}
                 ),
                 interval=interval,
                 view=monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
@@ -233,7 +229,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             filter_str_template = (
                 'metric.type = "%(metric)s" AND '
                 'metric.labels.grpc_status = "OK" AND '
-                'metric.labels.grpc_method = "%(grpc_method)s"'
+                f'metric.labels.grpc_method = "{GRPC_METHOD_NAME}"'
             )
             histogram_results = self.query_metrics(
                 HISTOGRAM_METRICS, filter_str_template, interval
@@ -243,7 +239,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             # 'grpc_status' label
             filter_str_template = (
                 'metric.type = "%(metric)s" AND '
-                'metric.labels.grpc_method = "%(grpc_method)s"'
+                f'metric.labels.grpc_method = "{GRPC_METHOD_NAME}"'
             )
             counter_results = self.query_metrics(
                 COUNTER_METRICS, filter_str_template, interval
@@ -280,7 +276,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                         "csm_service_namespace_name": self.server_namespace,
                         "csm_workload_canonical_service": CSM_CANONICAL_SERVICE_NAME_CLIENT,
                         "grpc_method": GRPC_METHOD_NAME,
-                        "grpc_status": VALUE_NOT_CHECKED,
+                        "grpc_status": "OK",
                         "grpc_target": VALUE_NOT_CHECKED,
                         "pod": self.test_client.hostname,
                     }
@@ -296,7 +292,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                         "csm_remote_workload_type": "gcp_kubernetes_engine",
                         "csm_workload_canonical_service": CSM_CANONICAL_SERVICE_NAME_SERVER,
                         "grpc_method": GRPC_METHOD_NAME,
-                        "grpc_status": VALUE_NOT_CHECKED,
+                        "grpc_status": "OK",
                         "pod": self.test_server.hostname,
                     }
                 elif metric in COUNTER_CLIENT_METRICS:

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -139,13 +139,13 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         super().setUpClass()
         cls.metric_client = cls.gcp_api_manager.monitoring_metric_service("v3")
 
-    def initKubernetesClientRunner(self) -> KubernetesClientRunner:
+    def initKubernetesClientRunner(self, **kwargs) -> KubernetesClientRunner:
         return super().initKubernetesClientRunner(
             csm_workload_name=CSM_WORKLOAD_NAME_CLIENT,
             csm_canonical_service_name=CSM_CANONICAL_SERVICE_NAME_CLIENT,
         )
 
-    def initKubernetesServerRunner(self) -> GammaServerRunner:
+    def initKubernetesServerRunner(self, **kwargs) -> GammaServerRunner:
         return super().initKubernetesServerRunner(
             csm_workload_name=CSM_WORKLOAD_NAME_SERVER,
             csm_canonical_service_name=CSM_CANONICAL_SERVICE_NAME_SERVER,


### PR DESCRIPTION
This PR adds some assertions to test whether the metrics generated by the CSM Observability Test match what we expect.

We use the `list_time_series` cloud monitoring API to query metrics we just generated by the test run, and then verify whether the metrics data (label keys and values, and data points) is what we expected.