### PR TITLE
Add --generate-mesh-id-experimental flag to server bootstrap

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -116,6 +116,7 @@ class GammaServerRunner(KubernetesServerRunner):
         bootstrap_version: Optional[str] = None,
         route_template: str = "gamma/route_http.yaml",
         enable_csm_observability: bool = False,
+        generate_mesh_id: bool = False,
     ) -> List[XdsTestServer]:
         if not maintenance_port:
             maintenance_port = self._get_default_maintenance_port(secure_mode)
@@ -208,6 +209,7 @@ class GammaServerRunner(KubernetesServerRunner):
             termination_grace_period_seconds=self.termination_grace_period_seconds,
             pre_stop_hook=self.pre_stop_hook,
             enable_csm_observability=enable_csm_observability,
+            generate_mesh_id=generate_mesh_id,
         )
 
         servers = self._make_servers_for_deployment(

--- a/framework/xds_gamma_testcase.py
+++ b/framework/xds_gamma_testcase.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import datetime
 import logging
-from typing import Optional
+from typing import List, Optional
 
 from framework.infrastructure import k8s
 import framework.infrastructure.traffic_director_gamma as td_gamma
@@ -138,4 +138,12 @@ class GammaXdsKubernetesTestCase(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             #     of the wait time spent on waiting ADS.
             wait_for_server_channel_ready_timeout=datetime.timedelta(minutes=9),
             **kwargs,
+        )
+
+    def startTestServers(
+        self, replica_count=1, server_runner=None, **kwargs,
+    ) -> List[XdsTestServer]:
+        kwargs.setdefault("generate_mesh_id", True)
+        return super().startTestServers(
+            replica_count=replica_count, server_runner=server_runner, **kwargs
         )

--- a/framework/xds_gamma_testcase.py
+++ b/framework/xds_gamma_testcase.py
@@ -141,7 +141,7 @@ class GammaXdsKubernetesTestCase(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         )
 
     def startTestServers(
-        self, replica_count=1, server_runner=None, **kwargs,
+        self, replica_count=1, server_runner=None, **kwargs
     ) -> List[XdsTestServer]:
         kwargs.setdefault("generate_mesh_id", True)
         return super().startTestServers(

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -84,6 +84,9 @@ spec:
             % else:
             - "--node-metadata=app=${namespace_name}-${deployment_name}"
             % endif
+            % if generate_mesh_id:
+            - "--generate-mesh-id-experimental"
+            % endif
           resources:
             limits:
               cpu: 100m

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -50,7 +50,8 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         #   resource creation out of self.startTestServers()
         with self.subTest("1_run_test_server"):
             test_server: _XdsTestServer = self.startTestServers(
-                enable_csm_observability=True
+                enable_csm_observability=True,
+                generate_mesh_id=True,
             )[0]
 
         with self.subTest("2_start_test_client"):

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -50,8 +50,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         #   resource creation out of self.startTestServers()
         with self.subTest("1_run_test_server"):
             test_server: _XdsTestServer = self.startTestServers(
-                enable_csm_observability=True,
-                generate_mesh_id=True,
+                enable_csm_observability=True
             )[0]
 
         with self.subTest("2_start_test_client"):


### PR DESCRIPTION
This flag has been added to the client deployment but not the server deployment. Adding it to server now.

We need this fix in order for the CSM Observability Test to properly record the server side metrics.