### PR TITLE
Fix bug with Gamma Server Runner not having GCP Logs link

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -20,6 +20,7 @@ from typing import List, Optional
 
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
+from framework.test_app.runners.k8s import k8s_base_runner
 from framework.test_app.runners.k8s import k8s_xds_server_runner
 from framework.test_app.server_app import XdsTestServer
 
@@ -134,7 +135,7 @@ class GammaServerRunner(KubernetesServerRunner):
             False,
             replica_count,
         )
-        # super(k8s_base_runner.KubernetesBaseRunner, self).run()
+        k8s_base_runner.KubernetesBaseRunner.run(self)
 
         if self.reuse_namespace:
             self.namespace = self._reuse_namespace()

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -137,13 +137,6 @@ class GammaServerRunner(KubernetesServerRunner):
         )
         k8s_base_runner.KubernetesBaseRunner.run(self)
 
-        if self.reuse_namespace:
-            self.namespace = self._reuse_namespace()
-        if not self.namespace:
-            self.namespace = self._create_namespace(
-                self.namespace_template, namespace_name=self.k8s_namespace.name
-            )
-
         # Reuse existing if requested, create a new deployment when missing.
         # Useful for debugging to avoid NEG loosing relation to deleted service.
         if self.reuse_service:


### PR DESCRIPTION
This fixes a bug with all the `GammaServerRunner` subclass not calling the super class `KubernetesBaseRunner`'s `run()` method properly, which causes the variable `self.time_start_requested` not being set and hence there is never `RunHistory` logged for the gamma server runner.

ref b/298501683