### PR TITLE
CSM Observability: update cpp version check to v1.62.x

### DIFF
--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -37,7 +37,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang == _Lang.CPP and config.server_lang == _Lang.CPP:
             # CSM Observability Test is only supported for CPP for now.
-            return config.version_gte("v1.61.x")
+            return config.version_gte("v1.62.x")
         return False
 
     @classmethod


### PR DESCRIPTION
Until (and if) all changes needed for CSM Observability are backported to `v1.61.x`, we should only allow this test for the  upcoming release `v1.62.x`, and the `master` branch.