### PR TITLE
update bootstrap image to v0.16.0

### DIFF
--- a/config/common.cfg
+++ b/config/common.cfg
@@ -1,5 +1,5 @@
 --resource_prefix=psm-interop
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:7d8d90477792e2e1bfe3a3da20b3dc9ef01d326c
+--td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:2bf1b5ed00f852ffea8d24759c6fa673acc9ef10
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,

--- a/tests/bootstrap_generator_test.py
+++ b/tests/bootstrap_generator_test.py
@@ -47,6 +47,14 @@ _timedelta = datetime.timedelta
 def bootstrap_version_testcases() -> List:
     return (
         dict(
+            version="v0.16.0",
+            image="gcr.io/grpc-testing/td-grpc-bootstrap:2bf1b5ed00f852ffea8d24759c6fa673acc9ef10",
+        ),
+        dict(
+            version="v0.15.0",
+            image="gcr.io/grpc-testing/td-grpc-bootstrap:7d8d90477792e2e1bfe3a3da20b3dc9ef01d326c",
+        ),
+        dict(
             version="v0.14.0",
             image="gcr.io/grpc-testing/td-grpc-bootstrap:d6baaf7b0e0c63054ac4d9bedc09021ff261d599",
         ),


### PR DESCRIPTION
- Update the default bootstrap to `2bf1b5ed00f852ffea8d24759c6fa673acc9ef10`
- Add `v0.15.0`, `v0.16.0` bootstrap versions to `bootstrap_version_testcases`