### PR TITLE
Fix URL Map setUpClass errors not framed with `PSM Failed Test ...`

### DIFF
--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -117,7 +117,8 @@ class BaseTestCase(absltest.TestCase):
             caller = "undefined_hook"
 
         fake_test_id = f"{cls.__name__}.{caller}"
-        # same cleanup as in self. test_name
+        # The same test name transformation as in self.test_name().
+        # TODO(sergiitk): move the transformation to a classmethod.
         test_name = fake_test_id.removeprefix("__main__.").split(" ", 1)[0]
         logging.error("----- PSM Test Case FAILED: %s -----", test_name)
         cls._log_framed_test_failure(test_name, error, is_unexpected=True)

--- a/tests/fake_test.py
+++ b/tests/fake_test.py
@@ -80,5 +80,24 @@ class FakeSubtestTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
                     self.fail(f"Integer {num} is odd")
 
 
+class FakeSetupClassTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
+    """A fake class to debug BaseTestCase logs produced by setupClassError.
+
+    See FakeTest for notes on provisioning.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            # Making bad external calls that end up raising
+            raise OSError("Network bad!")
+        except Exception as error:  # noqa pylint: disable=broad-except
+            cls._log_class_hook_failure(error)
+            raise
+
+    def test_should_never_run(self):
+        self.fail("IF YOU SEE ME, SOMETHING IS WRONG!")
+
+
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
Result:
```
❯ ./run.sh tests/fake_test.py FakeSetupClassTest
Running tests under Python 3.9.18: /Users/sergiitk/Development/psm-interop/venv/bin/python
E0215 10:17:22.403760 140704311461824 base_testcase.py:122] ----- PSM Test Case FAILED: FakeSetupClassTest.setUpClass -----
E0215 10:17:22.403939 140704311461824 base_testcase.py:141] (ERROR) PSM Interop Test Failed: FakeSetupClassTest.setUpClass
^^^^^
[FakeSetupClassTest.setUpClass] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 93, in setUpClass
    raise OSError("Network bad!")
OSError: Network bad!
[FakeSetupClassTest.setUpClass] PSM Failed Test Traceback END

[  FAILED  ] setUpClass (__main__.FakeSetupClassTest)
```