### PR TITLE
[CSM O11y] Avoid collisions between test runs when querying metrics

### DIFF
--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -398,7 +398,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         # The 'grpc_method' filter condition is needed because the
         # server metrics are also serving on the Channelz requests.
         #
-        # The 'csm_remote_workload_namespace_name' filter condition allows us to
+        # The 'resource.labels.namespace' filter condition allows us to
         # filter metrics just for the current test run.
         return (
             f'metric.type = "{metric_type}" AND '

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -201,25 +201,25 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 start_time={"seconds": start_secs},
                 end_time={"seconds": end_secs},
             )
-            histogram_results = self.query_metrics(
+            server_histogram_results = self.query_metrics(
                 HISTOGRAM_METRICS,
                 self.build_histogram_query,
                 self.client_namespace,
                 interval,
             )
-            histogram_results = self.query_metrics(
+            client_histogram_results = self.query_metrics(
                 HISTOGRAM_METRICS,
                 self.build_histogram_query,
                 self.server_namespace,
                 interval,
             )
-            counter_results = self.query_metrics(
+            server_counter_results = self.query_metrics(
                 COUNTER_METRICS,
                 self.build_counter_query,
                 self.client_namespace,
                 interval,
             )
-            counter_results = self.query_metrics(
+            client_counter_results = self.query_metrics(
                 COUNTER_METRICS,
                 self.build_counter_query,
                 self.server_namespace,
@@ -415,7 +415,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         self,
         metric_names: Iterable[str],
         build_query_fn: BuildQueryFn,
-        namespace: str,
+        remote_namespace: str,
         interval: monitoring_v3.TimeInterval,
     ) -> dict[str, MetricTimeSeries]:
         """
@@ -446,7 +446,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             logger.info("Requesting list_time_series for metric %s", metric)
             response = self.metric_client.list_time_series(
                 name=f"projects/{self.project}",
-                filter=build_query_fn(metric, namespace),
+                filter=build_query_fn(metric, remote_namespace),
                 interval=interval,
                 view=monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
                 retry=retry_settings,

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -202,25 +202,25 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 end_time={"seconds": end_secs},
             )
             server_histogram_results = self.query_metrics(
-                HISTOGRAM_METRICS,
+                HISTOGRAM_SERVER_METRICS,
                 self.build_histogram_query,
                 self.server_namespace,
                 interval,
             )
             client_histogram_results = self.query_metrics(
-                HISTOGRAM_METRICS,
+                HISTOGRAM_CLIENT_METRICS,
                 self.build_histogram_query,
                 self.client_namespace,
                 interval,
             )
             server_counter_results = self.query_metrics(
-                COUNTER_METRICS,
+                COUNTER_SERVER_METRICS,
                 self.build_counter_query,
                 self.server_namespace,
                 interval,
             )
             client_counter_results = self.query_metrics(
-                COUNTER_METRICS,
+                COUNTER_CLIENT_METRICS,
                 self.build_counter_query,
                 self.client_namespace,
                 interval,


### PR DESCRIPTION
We noticed a bug in CSM O11y test harness where we did not scope our metric queries to a particular test run. The fix is to add a scope on the client/server namespace which should be unique to a specific test run.