### PR TITLE
Replace functools.cached_property with property + functools.cache

### DIFF
--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -62,7 +62,8 @@ class PrettyStatsPerMethod:
     # }
     result: Dict[str, int]
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def rpcs_completed(self):
         """Returns the total count of competed RPCs across all statuses."""
         return sum(self.result.values())

--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -27,7 +27,7 @@ RpcMetadata = grpc_testing.LoadBalancerStatsResponse.RpcMetadata
 MetadataByPeer: list[str, RpcMetadata]
 
 
-@functools.cache  # pylint: disable=no-member
+@functools.cache
 def status_from_int(grpc_status_int: int) -> Optional[grpc.StatusCode]:
     """Converts the integer gRPC status code to the grpc.StatusCode enum."""
     for grpc_status in grpc.StatusCode:
@@ -63,7 +63,7 @@ class PrettyStatsPerMethod:
     result: Dict[str, int]
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def rpcs_completed(self):
         """Returns the total count of competed RPCs across all statuses."""
         return sum(self.result.values())

--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -295,46 +295,53 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
     def name(self):
         return self._name
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def api_gke_mesh(self) -> dynamic_res.Resource:
         return self._get_dynamic_api("net.gke.io/v1alpha1", "TDMesh")
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def api_grpc_route(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "gateway.networking.k8s.io/v1alpha2",
             "GRPCRoute",
         )
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def api_http_route(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "gateway.networking.k8s.io/v1beta1",
             "HTTPRoute",
         )
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def api_session_affinity_filter(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "networking.gke.io/v1",
             "GCPSessionAffinityFilter",
         )
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def api_session_affinity_policy(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "networking.gke.io/v1",
             "GCPSessionAffinityPolicy",
         )
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def pod_monitoring(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "monitoring.googleapis.com/v1",
             "PodMonitoring",
         )
 
-    @functools.cached_property  # pylint: disable=no-member
+    @property
+    @functools.cache  # pylint: disable=no-member
     def api_backend_policy(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "networking.gke.io/v1",

--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -146,7 +146,7 @@ class KubernetesApiManager:
     def dynamic_client(self) -> dynamic.DynamicClient:
         return self._dynamic_client
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def grpc_route(self, version: str) -> dynamic_res.Resource:
         api_name = "gateway.networking.k8s.io"
         kind = "GRPCRoute"
@@ -160,7 +160,7 @@ class KubernetesApiManager:
 
         return self._load_dynamic_api(api_name, version, kind)
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def http_route(self, version: str) -> dynamic_res.Resource:
         api_name = "gateway.networking.k8s.io"
         kind = "HTTPRoute"
@@ -172,7 +172,7 @@ class KubernetesApiManager:
 
         return self._load_dynamic_api(api_name, version, kind)
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def gcp_session_affinity_filter(self, version: str) -> dynamic_res.Resource:
         api_name = "networking.gke.io"
         kind = "GCPSessionAffinityFilter"
@@ -184,7 +184,7 @@ class KubernetesApiManager:
 
         return self._load_dynamic_api(api_name, version, kind)
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def gcp_session_affinity_policy(self, version: str) -> dynamic_res.Resource:
         api_name = "networking.gke.io"
         kind = "GCPSessionAffinityPolicy"
@@ -196,7 +196,7 @@ class KubernetesApiManager:
 
         return self._load_dynamic_api(api_name, version, kind)
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def gcp_backend_policy(self, version: str) -> dynamic_res.Resource:
         api_name = "networking.gke.io"
         kind = "GCPBackendPolicy"
@@ -208,7 +208,7 @@ class KubernetesApiManager:
 
         return self._load_dynamic_api(api_name, version, kind)
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def pod_monitoring(self, version: str) -> dynamic_res.Resource:
         api_name = "monitoring.googleapis.com"
         kind = "PodMonitoring"
@@ -296,12 +296,12 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         return self._name
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def api_gke_mesh(self) -> dynamic_res.Resource:
         return self._get_dynamic_api("net.gke.io/v1alpha1", "TDMesh")
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def api_grpc_route(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "gateway.networking.k8s.io/v1alpha2",
@@ -309,7 +309,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         )
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def api_http_route(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "gateway.networking.k8s.io/v1beta1",
@@ -317,7 +317,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         )
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def api_session_affinity_filter(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "networking.gke.io/v1",
@@ -325,7 +325,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         )
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def api_session_affinity_policy(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "networking.gke.io/v1",
@@ -333,7 +333,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         )
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def pod_monitoring(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "monitoring.googleapis.com/v1",
@@ -341,7 +341,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         )
 
     @property
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def api_backend_policy(self) -> dynamic_res.Resource:
         return self._get_dynamic_api(
             "networking.gke.io/v1",
@@ -367,7 +367,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         api = self._get_dynamic_api(manifest["apiVersion"], manifest["kind"])
         return api.create(manifest)
 
-    @functools.cache  # pylint: disable=no-member
+    @functools.cache
     def _get_dynamic_api(self, api_version, kind) -> dynamic_res.Resource:
         group, _, version = api_version.partition("/")
 


### PR DESCRIPTION
TIL `@functools.cached_property` allows writing to the attribute.

Allowing writes was intended in no methods in this framework.
Expected behavior always was to have lazy-loaded methods that return cached data per class instance, which is achieved with

```py
@property
@functools.cache
```

Note: Looks like `# pylint: disable=no-member` on functool methods is not needed anymore.