### PR TITLE
[Gamma] Bump the timeout for wait_service_neg_status_annotation to 4 mins

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -242,7 +242,7 @@ class GammaServerRunner(KubernetesServerRunner):
         self._wait_service_neg_status_annotation(
             self.service_name,
             test_port,
-            timeout_sec=datetime.timedelta(minutes=3).total_seconds(),
+            timeout_sec=datetime.timedelta(minutes=4).total_seconds(),
         )
 
         return servers

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -238,7 +238,7 @@ class GammaServerRunner(KubernetesServerRunner):
         # The controller will not populate the NEGs until there are
         # endpoint slices.
         # For this reason, we run this check after the servers were created,
-        # and increase the wait time from 1 minute to 3.
+        # and increased the default wait time (1m).
         self._wait_service_neg_status_annotation(
             self.service_name,
             test_port,


### PR DESCRIPTION
Gamma/CSM tests: 99 percentile of tests are passing, while we see a few failures in neg status annotation propagation on the service. The dashboards do not show anything strange. Bumping the timeout to 4 mins.

Ref b/298501683, b/298501683