### PR TITLE
Style: add typing-extensions per updated Google Python Style Guide 

### DIFF
--- a/.github/workflows/psm-interop.yaml
+++ b/.github/workflows/psm-interop.yaml
@@ -72,7 +72,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: isort/isort-action@v1
           with:
-            isort-version: "5.9.2"
+            isort-version: "5.13.2"
 
   pylint-check:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@ target-version = [
 [tool.isort]
 profile = "black"
 line_length = 80
-single_line_exclusions = ["typing"]
+single_line_exclusions = ["typing", "typing_extensions", "collections.abc"]
 force_single_line = true
 force_sort_within_sections = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,5 @@
 # Mirrors black version set in
 # https://github.com/grpc/grpc/blob/master/tools/distrib/black_code.sh
 black[d]==23.3.0
-isort~=5.9
+isort==5.13.2
 # TODO(https://github.com/grpc/grpc/pull/25872): mypy

--- a/requirements.lock
+++ b/requirements.lock
@@ -11,6 +11,7 @@ grpcio-channelz==1.60.1
 kubernetes==27.2.0
 six==1.16.0
 tenacity==6.3.1
+typing_extensions==4.10.0
 packaging==23.1
 Pygments==2.14.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ grpcio-channelz~=1.60
 kubernetes~=27.2
 six~=1.13
 tenacity~=6.2
+typing-extensions~=4.10
 packaging~=23.1
 Pygments~=2.9
 python-dateutil~=2.8


### PR DESCRIPTION
[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) has evolved, and looks all modern and futuristic now. I'll be getting tolling in this repo closer to match closer to it.

- Add [`typing-extensions`](https://typing-extensions.readthedocs.io/en/latest/) package.
- Configure isort single_line_exclusions according to https://google.github.io/styleguide/pyguide.html#2241-exemptions

With `typing-extensions`, we can use such cool things as [`TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias), [`Self`](https://docs.python.org/3/library/typing.html#typing.Self), and [`@override`](https://docs.python.org/3/library/typing.html#typing.override).

Note: we don't migrate the code to the new types yet, but we should be using these features when writing new code.