### PR TITLE
Fix incorrect dependency on xds_url_map_testcase for CSDS logic

### DIFF
--- a/framework/rpc/grpc_csds.py
+++ b/framework/rpc/grpc_csds.py
@@ -15,9 +15,12 @@
 This contains helpers for gRPC services defined in
 https://github.com/envoyproxy/envoy/blob/main/api/envoy/service/status/v3/csds.proto
 """
-
+import json
 import logging
-from typing import Optional
+import re
+from typing import Any, Optional
+
+from typing_extensions import TypeAlias
 
 # Needed to load the descriptors so that Any is parsed
 # TODO(sergiitk): replace with import xds_protos when it works
@@ -37,8 +40,100 @@ import framework.rpc
 logger = logging.getLogger(__name__)
 
 # Type aliases
-ClientConfig = csds_pb2.ClientConfig
-_ClientStatusRequest = csds_pb2.ClientStatusRequest
+ClientConfig: TypeAlias = csds_pb2.ClientConfig
+_ClientStatusRequest: TypeAlias = csds_pb2.ClientStatusRequest
+ClientStatusResponse: TypeAlias = csds_pb2.ClientStatusResponse
+JsonType: TypeAlias = dict[Any]
+
+
+class DumpedXdsConfig(dict):
+    """
+    A convenience class to check xDS config.
+
+    Feel free to add more pre-compute fields.
+    """
+
+    def __init__(self, xds_json: JsonType):  # pylint: disable=too-many-branches
+        super().__init__(xds_json)
+        self.json_config = xds_json
+        self.lds = None
+        self.rds = None
+        self.rds_version = None
+        self.cds = []
+        self.eds = []
+        self.endpoints = []
+        for xds_config in self.get("xdsConfig", []):
+            try:
+                if "listenerConfig" in xds_config:
+                    self.lds = xds_config["listenerConfig"]["dynamicListeners"][
+                        0
+                    ]["activeState"]["listener"]
+                elif "routeConfig" in xds_config:
+                    self.rds = xds_config["routeConfig"]["dynamicRouteConfigs"][
+                        0
+                    ]["routeConfig"]
+                    self.rds_version = xds_config["routeConfig"][
+                        "dynamicRouteConfigs"
+                    ][0]["versionInfo"]
+                elif "clusterConfig" in xds_config:
+                    for cluster in xds_config["clusterConfig"][
+                        "dynamicActiveClusters"
+                    ]:
+                        self.cds.append(cluster["cluster"])
+                elif "endpointConfig" in xds_config:
+                    for endpoint in xds_config["endpointConfig"][
+                        "dynamicEndpointConfigs"
+                    ]:
+                        self.eds.append(endpoint["endpointConfig"])
+            # TODO(lidiz) reduce the catch to LookupError
+            except Exception as e:  # pylint: disable=broad-except
+                logging.debug(
+                    "Parsing dumped xDS config failed with %s: %s", type(e), e
+                )
+        for generic_xds_config in self.get("genericXdsConfigs", []):
+            try:
+                if re.search(r"\.Listener$", generic_xds_config["typeUrl"]):
+                    self.lds = generic_xds_config["xdsConfig"]
+                elif re.search(
+                    r"\.RouteConfiguration$", generic_xds_config["typeUrl"]
+                ):
+                    self.rds = generic_xds_config["xdsConfig"]
+                    self.rds_version = generic_xds_config["versionInfo"]
+                elif re.search(r"\.Cluster$", generic_xds_config["typeUrl"]):
+                    self.cds.append(generic_xds_config["xdsConfig"])
+                elif re.search(
+                    r"\.ClusterLoadAssignment$", generic_xds_config["typeUrl"]
+                ):
+                    self.eds.append(generic_xds_config["xdsConfig"])
+            # TODO(lidiz) reduce the catch to LookupError
+            except Exception as e:  # pylint: disable=broad-except
+                logging.debug(
+                    "Parsing dumped xDS config failed with %s: %s", type(e), e
+                )
+        for endpoint_config in self.eds:
+            for endpoint in endpoint_config.get("endpoints", {}):
+                for lb_endpoint in endpoint.get("lbEndpoints", {}):
+                    try:
+                        if lb_endpoint["healthStatus"] == "HEALTHY":
+                            self.endpoints.append(
+                                "%s:%s"
+                                % (
+                                    lb_endpoint["endpoint"]["address"][
+                                        "socketAddress"
+                                    ]["address"],
+                                    lb_endpoint["endpoint"]["address"][
+                                        "socketAddress"
+                                    ]["portValue"],
+                                )
+                            )
+                    # TODO(lidiz) reduce the catch to LookupError
+                    except Exception as e:  # pylint: disable=broad-except
+                        logging.debug(
+                            "Parse endpoint failed with %s: %s", type(e), e
+                        )
+
+    def __str__(self) -> str:
+        return json.dumps(self, indent=2)
 
 
 class CsdsClient(framework.rpc.grpc.GrpcClientHelper):

--- a/framework/rpc/grpc_csds.py
+++ b/framework/rpc/grpc_csds.py
@@ -187,6 +187,6 @@ class CsdsClient(framework.rpc.grpc.GrpcClientHelper):
     def fetch_client_status_parsed(self, **kwargs) -> Optional[DumpedXdsConfig]:
         """Same as fetch_client_status, but also parses."""
         client_config = self.fetch_client_status(**kwargs)
-        if client_config is None:
-            return None
-        return DumpedXdsConfig.from_message(client_config)
+        if client_config:
+            return DumpedXdsConfig.from_message(client_config)
+        return None

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -30,7 +30,6 @@ import grpc
 
 from framework import xds_flags
 from framework import xds_k8s_flags
-from framework import xds_url_map_testcase
 from framework.helpers import grpc as helpers_grpc
 from framework.helpers import rand as helpers_rand
 from framework.helpers import retryers
@@ -560,12 +559,10 @@ class XdsKubernetesBaseTestCase(base_testcase.BaseTestCase):
             for attempt in retryer:
                 with attempt:
                     self.assertSuccessfulRpcs(test_client)
-                    raw_config = test_client.csds.fetch_client_status(
+                    dumped_config = test_client.csds.fetch_client_status_parsed(
                         log_level=logging.INFO
                     )
-                    dumped_config = xds_url_map_testcase.DumpedXdsConfig(
-                        json_format.MessageToDict(raw_config)
-                    )
+                    self.assertIsNotNone(dumped_config)
                     route_config_version = dumped_config.rds_version
                     if previous_route_config_version == route_config_version:
                         logger.info(

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -16,12 +16,10 @@
 import abc
 from dataclasses import dataclass
 import datetime
-import json
 import os
-import re
 import sys
 import time
-from typing import Any, Iterable, Mapping, Optional, Tuple
+from typing import Any, Iterable, Mapping, Optional, Tuple, TypeAlias
 import unittest
 
 from absl import flags
@@ -35,6 +33,7 @@ from framework.helpers import grpc as helpers_grpc
 from framework.helpers import retryers
 from framework.helpers import skips
 from framework.infrastructure import k8s
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 from framework.test_app.runners.k8s import k8s_xds_client_runner
 from framework.test_cases import base_testcase
@@ -62,6 +61,8 @@ PathMatcher = xds_url_map_test_resources.PathMatcher
 _KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
 JsonType = Any
 _timedelta = datetime.timedelta
+# TODO(sergiitk): should not be here! Move all usages to grpc_csds.
+DumpedXdsConfig: TypeAlias = grpc_csds.DumpedXdsConfig
 
 # ProtoBuf translatable RpcType enums
 RpcTypeUnaryCall = "UNARY_CALL"
@@ -73,95 +74,6 @@ def _split_camel(s: str, delimiter: str = "-") -> str:
     return "".join(
         delimiter + c.lower() if c.isupper() else c for c in s
     ).lstrip(delimiter)
-
-
-class DumpedXdsConfig(dict):
-    """A convenience class to check xDS config.
-
-    Feel free to add more pre-compute fields.
-    """
-
-    def __init__(self, xds_json: JsonType):  # pylint: disable=too-many-branches
-        super().__init__(xds_json)
-        self.json_config = xds_json
-        self.lds = None
-        self.rds = None
-        self.rds_version = None
-        self.cds = []
-        self.eds = []
-        self.endpoints = []
-        for xds_config in self.get("xdsConfig", []):
-            try:
-                if "listenerConfig" in xds_config:
-                    self.lds = xds_config["listenerConfig"]["dynamicListeners"][
-                        0
-                    ]["activeState"]["listener"]
-                elif "routeConfig" in xds_config:
-                    self.rds = xds_config["routeConfig"]["dynamicRouteConfigs"][
-                        0
-                    ]["routeConfig"]
-                    self.rds_version = xds_config["routeConfig"][
-                        "dynamicRouteConfigs"
-                    ][0]["versionInfo"]
-                elif "clusterConfig" in xds_config:
-                    for cluster in xds_config["clusterConfig"][
-                        "dynamicActiveClusters"
-                    ]:
-                        self.cds.append(cluster["cluster"])
-                elif "endpointConfig" in xds_config:
-                    for endpoint in xds_config["endpointConfig"][
-                        "dynamicEndpointConfigs"
-                    ]:
-                        self.eds.append(endpoint["endpointConfig"])
-            # TODO(lidiz) reduce the catch to LookupError
-            except Exception as e:  # pylint: disable=broad-except
-                logging.debug(
-                    "Parsing dumped xDS config failed with %s: %s", type(e), e
-                )
-        for generic_xds_config in self.get("genericXdsConfigs", []):
-            try:
-                if re.search(r"\.Listener$", generic_xds_config["typeUrl"]):
-                    self.lds = generic_xds_config["xdsConfig"]
-                elif re.search(
-                    r"\.RouteConfiguration$", generic_xds_config["typeUrl"]
-                ):
-                    self.rds = generic_xds_config["xdsConfig"]
-                    self.rds_version = generic_xds_config["versionInfo"]
-                elif re.search(r"\.Cluster$", generic_xds_config["typeUrl"]):
-                    self.cds.append(generic_xds_config["xdsConfig"])
-                elif re.search(
-                    r"\.ClusterLoadAssignment$", generic_xds_config["typeUrl"]
-                ):
-                    self.eds.append(generic_xds_config["xdsConfig"])
-            # TODO(lidiz) reduce the catch to LookupError
-            except Exception as e:  # pylint: disable=broad-except
-                logging.debug(
-                    "Parsing dumped xDS config failed with %s: %s", type(e), e
-                )
-        for endpoint_config in self.eds:
-            for endpoint in endpoint_config.get("endpoints", {}):
-                for lb_endpoint in endpoint.get("lbEndpoints", {}):
-                    try:
-                        if lb_endpoint["healthStatus"] == "HEALTHY":
-                            self.endpoints.append(
-                                "%s:%s"
-                                % (
-                                    lb_endpoint["endpoint"]["address"][
-                                        "socketAddress"
-                                    ]["address"],
-                                    lb_endpoint["endpoint"]["address"][
-                                        "socketAddress"
-                                    ]["portValue"],
-                                )
-                            )
-                    # TODO(lidiz) reduce the catch to LookupError
-                    except Exception as e:  # pylint: disable=broad-except
-                        logging.debug(
-                            "Parse endpoint failed with %s: %s", type(e), e
-                        )
-
-    def __str__(self) -> str:
-        return json.dumps(self, indent=2)
 
 
 class RpcDistributionStats:

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -19,7 +19,7 @@ import datetime
 import os
 import sys
 import time
-from typing import Any, Iterable, Mapping, Optional, Tuple, TypeAlias
+from typing import Any, Iterable, Mapping, Optional, Tuple
 import unittest
 
 from absl import flags
@@ -61,8 +61,6 @@ PathMatcher = xds_url_map_test_resources.PathMatcher
 _KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
 JsonType = Any
 _timedelta = datetime.timedelta
-# TODO(sergiitk): should not be here! Move all usages to grpc_csds.
-DumpedXdsConfig: TypeAlias = grpc_csds.DumpedXdsConfig
 
 # ProtoBuf translatable RpcType enums
 RpcTypeUnaryCall = "UNARY_CALL"
@@ -247,7 +245,9 @@ class XdsUrlMapTestCase(
         """
 
     @abc.abstractmethod
-    def xds_config_validate(self, xds_config: DumpedXdsConfig) -> None:
+    def xds_config_validate(
+        self, xds_config: grpc_csds.DumpedXdsConfig
+    ) -> None:
         """Validates received xDS config, if anything is wrong, raise.
 
         This stage only ends when the control plane failed to send a valid
@@ -373,17 +373,17 @@ class XdsUrlMapTestCase(
         # TODO(lidiz) find another way to store last seen xDS config
         # Cleanup state for this attempt
         # pylint: disable=attribute-defined-outside-init
-        self._xds_json_config = None
+        self._client_config_dict = None
         # Fetch client config
-        config = self.test_client.csds.fetch_client_status(
+        parsed = self.test_client.csds.fetch_client_status_parsed(
             log_level=logging.INFO
         )
-        self.assertIsNotNone(config)
+        self.assertIsNotNone(parsed)
         # Found client config, test it.
-        self._xds_json_config = json_format.MessageToDict(config)
+        self._client_config_dict = parsed.client_config_dict
         # pylint: enable=attribute-defined-outside-init
         # Execute the child class provided validation logic
-        self.xds_config_validate(DumpedXdsConfig(self._xds_json_config))
+        self.xds_config_validate(parsed)
 
     def run(self, result: unittest.TestResult = None) -> None:
         """Abort this test case if CSDS check is failed.
@@ -414,7 +414,7 @@ class XdsUrlMapTestCase(
             logging.info(
                 "latest xDS config:\n%s",
                 GcpResourceManager().td.compute.resource_pretty_format(
-                    self._xds_json_config
+                    self._client_config_dict
                 ),
             )
 
@@ -444,7 +444,11 @@ class XdsUrlMapTestCase(
         )
         return RpcDistributionStats(json_format.MessageToDict(lb_stats))
 
-    def assertNumEndpoints(self, xds_config: DumpedXdsConfig, k: int) -> None:
+    def assertNumEndpoints(
+        self,
+        xds_config: grpc_csds.DumpedXdsConfig,
+        k: int,
+    ) -> None:
         self.assertLen(
             xds_config.endpoints,
             k,

--- a/tests/affinity_test.py
+++ b/tests/affinity_test.py
@@ -99,12 +99,10 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                 metadata="EmptyCall:%s:123" % _TEST_AFFINITY_METADATA_KEY,
             )
             # Validate the number of received endpoints and affinity configs.
-            config = test_client.csds.fetch_client_status(
+            parsed = test_client.csds.fetch_client_status_parsed(
                 log_level=logging.INFO
             )
-            self.assertIsNotNone(config)
-            json_config = json_format.MessageToDict(config)
-            parsed = xds_url_map_testcase.DumpedXdsConfig(json_config)
+            self.assertIsNotNone(parsed)
             logging.info("Client received CSDS response: %s", parsed)
             self.assertLen(parsed.endpoints, _REPLICA_COUNT)
             self.assertEqual(
@@ -161,12 +159,10 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             parsed = None
             try:
                 while time.time() < deadline:
-                    config = test_client.csds.fetch_client_status(
+                    parsed = test_client.csds.fetch_client_status_parsed(
                         log_level=logging.INFO
                     )
-                    self.assertIsNotNone(config)
-                    json_config = json_format.MessageToDict(config)
-                    parsed = xds_url_map_testcase.DumpedXdsConfig(json_config)
+                    self.assertIsNotNone(parsed)
                     if len(parsed.endpoints) == _REPLICA_COUNT - 1:
                         break
                     logging.info(

--- a/tests/api_listener_test.py
+++ b/tests/api_listener_test.py
@@ -15,10 +15,8 @@ import logging
 
 from absl import flags
 from absl.testing import absltest
-from google.protobuf import json_format
 
 from framework import xds_k8s_testcase
-from framework import xds_url_map_testcase
 from framework.helpers import skips
 
 logger = logging.getLogger(__name__)
@@ -27,7 +25,6 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 # Type aliases
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
-_DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 _Lang = skips.Lang
 
 _TD_CONFIG_RETRY_WAIT_SEC = 2
@@ -100,12 +97,10 @@ class ApiListenerTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
         with self.subTest("13_test_server_received_rpcs_with_two_url_maps"):
             self.assertSuccessfulRpcs(test_client)
-            raw_config = test_client.csds.fetch_client_status(
+            dumped_config = test_client.csds.fetch_client_status_parsed(
                 log_level=logging.INFO
             )
-            dumped_config = _DumpedXdsConfig(
-                json_format.MessageToDict(raw_config)
-            )
+            self.assertIsNotNone(dumped_config)
             previous_route_config_version = dumped_config.rds_version
             logger.info(
                 (

--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -77,7 +77,7 @@ class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                     test_servers[0]
                 )
                 # Validate the number of received endpoints
-                parsed = test_client.csds.fetch_client_status(
+                parsed = test_client.csds.fetch_client_status_parsed(
                     log_level=logging.INFO
                 )
                 self.assertIsNotNone(parsed)

--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -18,10 +18,8 @@ from typing import List
 from absl import flags
 from absl import logging
 from absl.testing import absltest
-from google.protobuf import json_format
 
 from framework import xds_k8s_testcase
-from framework import xds_url_map_testcase
 from framework.helpers import skips
 
 flags.adopt_module_key_flags(xds_k8s_testcase)
@@ -79,12 +77,10 @@ class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                     test_servers[0]
                 )
                 # Validate the number of received endpoints
-                config = test_client.csds.fetch_client_status(
+                parsed = test_client.csds.fetch_client_status(
                     log_level=logging.INFO
                 )
-                self.assertIsNotNone(config)
-                json_config = json_format.MessageToDict(config)
-                parsed = xds_url_map_testcase.DumpedXdsConfig(json_config)
+                self.assertIsNotNone(parsed)
                 logging.info(
                     "Client %d received endpoints (len=%s): %s",
                     i,

--- a/tests/url_map/affinity_test.py
+++ b/tests/url_map/affinity_test.py
@@ -21,13 +21,13 @@ from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.infrastructure import traffic_director
 from framework.rpc import grpc_channelz
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
@@ -99,7 +99,7 @@ class TestHeaderBasedAffinity(xds_url_map_testcase.XdsUrlMapTestCase):
         ] = GcpResourceManager().affinity_backend_service()
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         # 3 endpoints in the affinity backend service.
         self.assertNumEndpoints(xds_config, 3)
         self.assertEqual(
@@ -174,7 +174,7 @@ class TestHeaderBasedAffinityMultipleHeaders(
         ] = GcpResourceManager().affinity_backend_service()
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         # 3 endpoints in the affinity backend service.
         self.assertNumEndpoints(xds_config, 3)
         self.assertEqual(

--- a/tests/url_map/csds_test.py
+++ b/tests/url_map/csds_test.py
@@ -19,13 +19,13 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
@@ -50,7 +50,7 @@ class TestBasicCsds(xds_url_map_testcase.XdsUrlMapTestCase):
     ) -> Tuple[HostRule, PathMatcher]:
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         # Validate Endpoint Configs
         self.assertNumEndpoints(xds_config, 1)
         # Validate Node

--- a/tests/url_map/fault_injection_test.py
+++ b/tests/url_map/fault_injection_test.py
@@ -21,13 +21,13 @@ import grpc
 
 from framework import xds_url_map_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
@@ -147,7 +147,7 @@ class TestZeroPercentFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         filter_config = xds_config.rds["virtualHosts"][0]["routes"][0][
             "typedPerFilterConfig"
@@ -211,7 +211,7 @@ class TestNonMatchingFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         # The first route rule for UNARY_CALL is fault injected
         self.assertEqual(
@@ -275,7 +275,7 @@ class TestAlwaysDelay(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         filter_config = xds_config.rds["virtualHosts"][0]["routes"][0][
             "typedPerFilterConfig"
@@ -326,7 +326,7 @@ class TestAlwaysAbort(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         filter_config = xds_config.rds["virtualHosts"][0]["routes"][0][
             "typedPerFilterConfig"
@@ -373,7 +373,7 @@ class TestDelayHalf(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         filter_config = xds_config.rds["virtualHosts"][0]["routes"][0][
             "typedPerFilterConfig"
@@ -424,7 +424,7 @@ class TestAbortHalf(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         filter_config = xds_config.rds["virtualHosts"][0]["routes"][0][
             "typedPerFilterConfig"

--- a/tests/url_map/header_matching_test.py
+++ b/tests/url_map/header_matching_test.py
@@ -19,13 +19,13 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
@@ -88,7 +88,7 @@ class TestExactMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][
@@ -146,7 +146,7 @@ class TestPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][
@@ -203,7 +203,7 @@ class TestSuffixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][
@@ -260,7 +260,7 @@ class TestPresentMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][
@@ -319,7 +319,7 @@ class TestInvertMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][
@@ -383,7 +383,7 @@ class TestRangeMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][
@@ -456,7 +456,7 @@ class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         )
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["headers"][

--- a/tests/url_map/metadata_filter_test.py
+++ b/tests/url_map/metadata_filter_test.py
@@ -18,13 +18,13 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_url_map_testcase
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
@@ -95,7 +95,7 @@ class TestMetadataFilterMatchAll(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(len(xds_config.rds["virtualHosts"][0]["routes"]), 2)
         self.assertEqual(
@@ -170,7 +170,7 @@ class TestMetadataFilterMatchAny(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(len(xds_config.rds["virtualHosts"][0]["routes"]), 2)
         self.assertEqual(
@@ -230,7 +230,7 @@ class TestMetadataFilterMatchAnyAndAll(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(len(xds_config.rds["virtualHosts"][0]["routes"]), 2)
         self.assertEqual(
@@ -298,7 +298,7 @@ class TestMetadataFilterMatchMultipleRules(
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(len(xds_config.rds["virtualHosts"][0]["routes"]), 3)
         self.assertEqual(

--- a/tests/url_map/path_matching_test.py
+++ b/tests/url_map/path_matching_test.py
@@ -19,13 +19,13 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
@@ -64,7 +64,7 @@ class TestFullPathMatchEmptyCall(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["path"],
@@ -101,7 +101,7 @@ class TestFullPathMatchUnaryCall(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["path"],
@@ -151,7 +151,7 @@ class TestTwoRoutesAndPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["prefix"],
@@ -202,7 +202,7 @@ class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"][
@@ -245,7 +245,7 @@ class TestCaseInsensitiveMatch(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 2)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["match"]["path"],

--- a/tests/url_map/retry_test.py
+++ b/tests/url_map/retry_test.py
@@ -20,13 +20,13 @@ import grpc
 
 from framework import xds_url_map_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 XdsTestClient = client_app.XdsTestClient
 ExpectedResult = xds_url_map_testcase.ExpectedResult
@@ -91,7 +91,7 @@ class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         retry_config = xds_config.rds["virtualHosts"][0]["routes"][0]["route"][
             "retryPolicy"
@@ -142,7 +142,7 @@ class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         retry_config = xds_config.rds["virtualHosts"][0]["routes"][0]["route"][
             "retryPolicy"

--- a/tests/url_map/timeout_test.py
+++ b/tests/url_map/timeout_test.py
@@ -21,13 +21,13 @@ import grpc
 
 from framework import xds_url_map_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_csds
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-DumpedXdsConfig = xds_url_map_testcase.DumpedXdsConfig
 RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 ExpectedResult = xds_url_map_testcase.ExpectedResult
@@ -65,7 +65,7 @@ class _BaseXdsTimeOutTestCase(XdsUrlMapTestCase):
         ]
         return host_rule, path_matcher
 
-    def xds_config_validate(self, xds_config: DumpedXdsConfig):
+    def xds_config_validate(self, xds_config: grpc_csds.DumpedXdsConfig):
         self.assertNumEndpoints(xds_config, 1)
         self.assertEqual(
             xds_config.rds["virtualHosts"][0]["routes"][0]["route"][


### PR DESCRIPTION
Some tests incorrectly on `framework.xds_url_map_testcase` to get `DumpedXdsConfig`. This should have never been the case: csds logic and helper should be `framework.rpc.grpc_csds`.

This is especially wrong in `framework.xds_k8s_testcase` depending on `framework.xds_url_map_testcase`, while `framework.xds_url_map_testcase` depends on `framework.xds_k8s_testcase`. I'm surprised this didn't cause more problems.

This PR:
1. Moves `DumpedXdsConfig` to `framework.rpc.grpc_csds`
2. Refactors `DumpedXdsConfig` for readability
3. Addresses TODO wrt catching broad exception while parsing
4. Adds CsdsClient.fetch_client_status_parsed that returns `DumpedXdsConfig` so class users don't need to depend on json
5. Replaces all imports of `xds_url_map_testcase` that were needed just for `DumpedXdsConfig` with imports of `grpc_csds`
