### PR TITLE
Fix incorrect dependency on xds_url_map_testcase for client config logic

### DIFF
--- a/framework/rpc/grpc_testing.py
+++ b/framework/rpc/grpc_testing.py
@@ -16,7 +16,7 @@ This contains helpers for gRPC services defined in
 https://github.com/grpc/grpc/blob/master/src/proto/grpc/testing/test.proto
 """
 import logging
-from typing import Iterable, Optional, Tuple
+from typing import Final, Iterable, Optional, Tuple
 
 import grpc
 from grpc_health.v1 import health_pb2
@@ -38,6 +38,11 @@ LoadBalancerAccumulatedStatsResponse = (
 )
 MethodStats = messages_pb2.LoadBalancerAccumulatedStatsResponse.MethodStats
 RpcsByPeer = messages_pb2.LoadBalancerStatsResponse.RpcsByPeer
+
+# Constants.
+# ProtoBuf translatable RpcType enums
+RPC_TYPE_UNARY_CALL: Final[str] = "UNARY_CALL"
+RPC_TYPE_EMPTY_CALL: Final[str] = "EMPTY_CALL"
 
 
 class LoadBalancerStatsServiceClient(framework.rpc.grpc.GrpcClientHelper):

--- a/framework/rpc/grpc_testing.py
+++ b/framework/rpc/grpc_testing.py
@@ -130,7 +130,7 @@ class XdsUpdateClientConfigureServiceClient(
         rpc_types: Sequence[str],
         metadata: Optional[ConfigureMetadata] = None,
         app_timeout: Optional[int] = None,
-        timeout_sec: int = CONFIGURE_TIMEOUT_SEC,
+        timeout_sec: Optional[int] = CONFIGURE_TIMEOUT_SEC,
     ) -> None:
         request = messages_pb2.ClientConfigureRequest()
         for rpc_type in rpc_types:
@@ -150,6 +150,9 @@ class XdsUpdateClientConfigureServiceClient(
                 )
         if app_timeout:
             request.timeout_sec = app_timeout
+        if timeout_sec is None:
+            timeout_sec = self.CONFIGURE_TIMEOUT_SEC
+
         # The response is empty.
         self.call_unary_with_deadline(
             rpc="Configure",
@@ -163,7 +166,7 @@ class XdsUpdateClientConfigureServiceClient(
         *,
         metadata: Optional[ConfigureMetadata] = None,
         app_timeout: Optional[int] = None,
-        timeout_sec: int = CONFIGURE_TIMEOUT_SEC,
+        timeout_sec: Optional[int] = CONFIGURE_TIMEOUT_SEC,
     ) -> None:
         self.configure(
             rpc_types=(RPC_TYPE_UNARY_CALL,),
@@ -177,25 +180,10 @@ class XdsUpdateClientConfigureServiceClient(
         *,
         metadata: Optional[ConfigureMetadata] = None,
         app_timeout: Optional[int] = None,
-        timeout_sec: int = CONFIGURE_TIMEOUT_SEC,
+        timeout_sec: Optional[int] = CONFIGURE_TIMEOUT_SEC,
     ) -> None:
         self.configure(
             rpc_types=(RPC_TYPE_EMPTY_CALL,),
-            metadata=metadata,
-            app_timeout=app_timeout,
-            timeout_sec=timeout_sec,
-        )
-
-    def configure_rpc_type(
-        self,
-        *,
-        rpc_type: str,
-        metadata: Optional[ConfigureMetadata] = None,
-        app_timeout: Optional[int] = None,
-        timeout_sec: int = CONFIGURE_TIMEOUT_SEC,
-    ) -> None:
-        self.configure(
-            rpc_types=(rpc_type,),
             metadata=metadata,
             app_timeout=app_timeout,
             timeout_sec=timeout_sec,

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -19,7 +19,7 @@ import datetime
 import os
 import sys
 import time
-from typing import Any, Final, Iterable, Mapping, Optional, Tuple
+from typing import Any, Final, Iterable, Mapping, Optional, Sequence, Tuple
 import unittest
 
 from absl import flags
@@ -138,7 +138,7 @@ class RpcDistributionStats:
 class ExpectedResult:
     """Describes the expected result of assertRpcStatusCode method below."""
 
-    rpc_type: str = RpcTypeUnaryCall
+    rpc_type: str = grpc_testing.RPC_TYPE_UNARY_CALL
     status_code: grpc.StatusCode = grpc.StatusCode.OK
     ratio: float = 1
 
@@ -427,8 +427,8 @@ class XdsUrlMapTestCase(
         cls,
         test_client: XdsTestClient,
         *,
-        rpc_types: Iterable[str],
-        metadata: Optional[Iterable[Tuple[str, str, str]]] = None,
+        rpc_types: Sequence[str],
+        metadata: Optional[grpc_testing.ConfigureMetadata] = None,
         app_timeout: Optional[int] = None,
         num_rpcs: int,
     ) -> RpcDistributionStats:

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -19,7 +19,7 @@ import datetime
 import os
 import sys
 import time
-from typing import Any, Iterable, Mapping, Optional, Tuple
+from typing import Any, Final, Iterable, Mapping, Optional, Tuple
 import unittest
 
 from absl import flags
@@ -34,6 +34,7 @@ from framework.helpers import retryers
 from framework.helpers import skips
 from framework.infrastructure import k8s
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 from framework.test_app.runners.k8s import k8s_xds_client_runner
 from framework.test_cases import base_testcase
@@ -62,9 +63,9 @@ _KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
 JsonType = Any
 _timedelta = datetime.timedelta
 
-# ProtoBuf translatable RpcType enums
-RpcTypeUnaryCall = "UNARY_CALL"
-RpcTypeEmptyCall = "EMPTY_CALL"
+# TODO(sergiitk): should not be here! Move all usages to grpc_testing.
+RpcTypeUnaryCall: Final[str] = grpc_testing.RPC_TYPE_UNARY_CALL
+RpcTypeEmptyCall: Final[str] = grpc_testing.RPC_TYPE_EMPTY_CALL
 
 
 def _split_camel(s: str, delimiter: str = "-") -> str:

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -19,7 +19,7 @@ import datetime
 import os
 import sys
 import time
-from typing import Any, Final, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
 import unittest
 
 from absl import flags
@@ -62,10 +62,6 @@ PathMatcher = xds_url_map_test_resources.PathMatcher
 _KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
 JsonType = Any
 _timedelta = datetime.timedelta
-
-# TODO(sergiitk): should not be here! Move all usages to grpc_testing.
-RpcTypeUnaryCall: Final[str] = grpc_testing.RPC_TYPE_UNARY_CALL
-RpcTypeEmptyCall: Final[str] = grpc_testing.RPC_TYPE_EMPTY_CALL
 
 
 def _split_camel(s: str, delimiter: str = "-") -> str:

--- a/tests/app_net_ssa_test.py
+++ b/tests/app_net_ssa_test.py
@@ -18,7 +18,6 @@ from absl import flags
 from absl.testing import absltest
 
 from framework import xds_k8s_testcase
-from framework import xds_url_map_testcase
 from framework.rpc import grpc_testing
 from framework.test_app import client_app
 from framework.test_cases import session_affinity_util
@@ -28,7 +27,6 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 
 _REPLICA_COUNT = 3
 
@@ -113,14 +111,9 @@ class AppNetSsaTest(xds_k8s_testcase.AppNetXdsKubernetesTestCase):
             )
 
         with self.subTest("8_send_RPCs_with_cookie"):
-            test_client.update_config.configure(
-                rpc_types=(RpcTypeUnaryCall,),
+            test_client.update_config.configure_unary(
                 metadata=(
-                    (
-                        RpcTypeUnaryCall,
-                        "cookie",
-                        cookie,
-                    ),
+                    (grpc_testing.RPC_TYPE_UNARY_CALL, "cookie", cookie),
                 ),
             )
             self.assertRpcsEventuallyGoToGivenServers(

--- a/tests/custom_lb_test.py
+++ b/tests/custom_lb_test.py
@@ -21,6 +21,7 @@ import grpc
 from framework import xds_k8s_flags
 from framework import xds_k8s_testcase
 from framework.helpers import skips
+from framework.rpc import grpc_testing
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)
@@ -121,7 +122,7 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                 test_client,
                 expected_status=_EXPECTED_STATUS,
                 duration=datetime.timedelta(seconds=10),
-                method="UNARY_CALL",
+                method=grpc_testing.RPC_TYPE_UNARY_CALL,
             )
 
 

--- a/tests/gamma/affinity_test.py
+++ b/tests/gamma/affinity_test.py
@@ -19,7 +19,6 @@ from absl.testing import absltest
 
 from framework import xds_gamma_testcase
 from framework import xds_k8s_testcase
-from framework import xds_url_map_testcase
 from framework.rpc import grpc_testing
 from framework.test_app import client_app
 from framework.test_app import server_app
@@ -30,7 +29,6 @@ flags.adopt_module_key_flags(xds_k8s_testcase)
 
 _XdsTestServer = server_app.XdsTestServer
 _XdsTestClient = client_app.XdsTestClient
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 
 _REPLICA_COUNT = 3
 
@@ -80,14 +78,9 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             )
 
         with self.subTest("05_send_RPCs_with_cookie"):
-            test_client.update_config.configure(
-                rpc_types=(RpcTypeUnaryCall,),
+            test_client.update_config.configure_unary(
                 metadata=(
-                    (
-                        RpcTypeUnaryCall,
-                        "cookie",
-                        cookie,
-                    ),
+                    (grpc_testing.RPC_TYPE_UNARY_CALL, "cookie", cookie),
                 ),
             )
             self.assertRpcsEventuallyGoToGivenServers(
@@ -118,14 +111,9 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             )
 
         with self.subTest("05_send_RPCs_with_cookie"):
-            test_client.update_config.configure(
-                rpc_types=(RpcTypeUnaryCall,),
+            test_client.update_config.configure_unary(
                 metadata=(
-                    (
-                        RpcTypeUnaryCall,
-                        "cookie",
-                        cookie,
-                    ),
+                    (grpc_testing.RPC_TYPE_UNARY_CALL, "cookie", cookie),
                 ),
             )
             self.assertRpcsEventuallyGoToGivenServers(
@@ -156,14 +144,9 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             )
 
         with self.subTest("05_send_RPCs_with_cookie"):
-            test_client.update_config.configure(
-                rpc_types=(RpcTypeUnaryCall,),
+            test_client.update_config.configure_unary(
                 metadata=(
-                    (
-                        RpcTypeUnaryCall,
-                        "cookie",
-                        cookie,
-                    ),
+                    (grpc_testing.RPC_TYPE_UNARY_CALL, "cookie", cookie),
                 ),
             )
             self.assertRpcsEventuallyGoToGivenServers(

--- a/tests/url_map/affinity_test.py
+++ b/tests/url_map/affinity_test.py
@@ -22,14 +22,13 @@ from framework.helpers import skips
 from framework.infrastructure import traffic_director
 from framework.rpc import grpc_channelz
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
-RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 _Lang = skips.Lang
 
@@ -44,10 +43,18 @@ _TEST_METADATA_NUMERIC_KEY = "xds_md_numeric"
 _TEST_METADATA_NUMERIC_VALUE = "159"
 
 _TEST_METADATA = (
-    (RpcTypeUnaryCall, _TEST_METADATA_KEY, _TEST_METADATA_VALUE_UNARY),
-    (RpcTypeEmptyCall, _TEST_METADATA_KEY, _TEST_METADATA_VALUE_EMPTY),
     (
-        RpcTypeUnaryCall,
+        grpc_testing.RPC_TYPE_UNARY_CALL,
+        _TEST_METADATA_KEY,
+        _TEST_METADATA_VALUE_UNARY,
+    ),
+    (
+        grpc_testing.RPC_TYPE_EMPTY_CALL,
+        _TEST_METADATA_KEY,
+        _TEST_METADATA_VALUE_EMPTY,
+    ),
+    (
+        grpc_testing.RPC_TYPE_UNARY_CALL,
         _TEST_METADATA_NUMERIC_KEY,
         _TEST_METADATA_NUMERIC_VALUE,
     ),
@@ -113,7 +120,7 @@ class TestHeaderBasedAffinity(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -133,7 +140,7 @@ class TestHeaderBasedAffinity(xds_url_map_testcase.XdsUrlMapTestCase):
         # backends. After this, we expect to see all backends to be connected.
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall, RpcTypeUnaryCall],
+            rpc_types=grpc_testing.RPC_TYPES_BOTH_CALLS,
             num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(3, rpc_distribution.num_peers)
@@ -188,7 +195,7 @@ class TestHeaderBasedAffinityMultipleHeaders(
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -225,15 +232,15 @@ class TestHeaderBasedAffinityMultipleHeaders(
         for i in range(30):
             new_metadata = (
                 (
-                    RpcTypeEmptyCall,
+                    grpc_testing.RPC_TYPE_EMPTY_CALL,
                     _TEST_METADATA_KEY,
                     _TEST_METADATA_VALUE_EMPTY,
                 ),
-                (RpcTypeUnaryCall, _TEST_METADATA_KEY, str(i)),
+                (grpc_testing.RPC_TYPE_UNARY_CALL, _TEST_METADATA_KEY, str(i)),
             )
             rpc_distribution = self.configure_and_send(
                 test_client,
-                rpc_types=[RpcTypeEmptyCall, RpcTypeUnaryCall],
+                rpc_types=grpc_testing.RPC_TYPES_BOTH_CALLS,
                 metadata=new_metadata,
                 num_rpcs=_NUM_RPCS,
             )

--- a/tests/url_map/csds_test.py
+++ b/tests/url_map/csds_test.py
@@ -20,14 +20,13 @@ from absl.testing import absltest
 from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
-RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 _Lang = skips.Lang
 
@@ -69,7 +68,7 @@ class TestBasicCsds(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeUnaryCall, RpcTypeEmptyCall],
+            rpc_types=grpc_testing.RPC_TYPES_BOTH_CALLS,
             num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(_NUM_RPCS, rpc_distribution.num_oks)

--- a/tests/url_map/fault_injection_test.py
+++ b/tests/url_map/fault_injection_test.py
@@ -22,14 +22,13 @@ import grpc
 from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
-RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 ExpectedResult = xds_url_map_testcase.ExpectedResult
 _Lang = skips.Lang
@@ -95,7 +94,7 @@ def _wait_until_backlog_cleared(
     while time.time() < deadline:
         stats = test_client.get_load_balancer_accumulated_stats()
         ok = True
-        for rpc_type in [RpcTypeUnaryCall, RpcTypeEmptyCall]:
+        for rpc_type in grpc_testing.RPC_TYPES_BOTH_CALLS:
             started = stats.num_rpcs_started_by_method.get(rpc_type, 0)
             completed = stats.num_rpcs_succeeded_by_method.get(
                 rpc_type, 0
@@ -169,13 +168,15 @@ class TestZeroPercentFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertRpcStatusCode(
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.OK,
                     ratio=1,
                 ),
@@ -248,7 +249,7 @@ class TestNonMatchingFaultInjection(xds_url_map_testcase.XdsUrlMapTestCase):
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeEmptyCall,
+                    rpc_type=grpc_testing.RPC_TYPE_EMPTY_CALL,
                     status_code=grpc.StatusCode.OK,
                     ratio=1,
                 ),
@@ -291,7 +292,7 @@ class TestAlwaysDelay(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
             test_client,
-            rpc_types=(RpcTypeUnaryCall,),
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
             num_rpcs=_NUM_RPCS,
             app_timeout=_DELAY_CASE_APPLICATION_TIMEOUT_SEC,
         )
@@ -300,7 +301,7 @@ class TestAlwaysDelay(xds_url_map_testcase.XdsUrlMapTestCase):
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.DEADLINE_EXCEEDED,
                     ratio=1,
                 ),
@@ -341,13 +342,15 @@ class TestAlwaysAbort(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertRpcStatusCode(
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.UNAUTHENTICATED,
                     ratio=1,
                 ),
@@ -389,7 +392,7 @@ class TestDelayHalf(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
             test_client,
-            rpc_types=(RpcTypeUnaryCall,),
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
             num_rpcs=_NUM_RPCS,
             app_timeout=_DELAY_CASE_APPLICATION_TIMEOUT_SEC,
         )
@@ -398,7 +401,7 @@ class TestDelayHalf(xds_url_map_testcase.XdsUrlMapTestCase):
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.DEADLINE_EXCEEDED,
                     ratio=0.5,
                 ),
@@ -439,13 +442,15 @@ class TestAbortHalf(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertRpcStatusCode(
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.UNAUTHENTICATED,
                     ratio=0.5,
                 ),

--- a/tests/url_map/header_matching_test.py
+++ b/tests/url_map/header_matching_test.py
@@ -20,14 +20,13 @@ from absl.testing import absltest
 from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
-RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 _Lang = skips.Lang
 
@@ -42,10 +41,18 @@ _TEST_METADATA_NUMERIC_KEY = "xds_md_numeric"
 _TEST_METADATA_NUMERIC_VALUE = "159"
 
 _TEST_METADATA = (
-    (RpcTypeUnaryCall, _TEST_METADATA_KEY, _TEST_METADATA_VALUE_UNARY),
-    (RpcTypeEmptyCall, _TEST_METADATA_KEY, _TEST_METADATA_VALUE_EMPTY),
     (
-        RpcTypeUnaryCall,
+        grpc_testing.RPC_TYPE_UNARY_CALL,
+        _TEST_METADATA_KEY,
+        _TEST_METADATA_VALUE_UNARY,
+    ),
+    (
+        grpc_testing.RPC_TYPE_EMPTY_CALL,
+        _TEST_METADATA_KEY,
+        _TEST_METADATA_VALUE_EMPTY,
+    ),
+    (
+        grpc_testing.RPC_TYPE_UNARY_CALL,
         _TEST_METADATA_NUMERIC_KEY,
         _TEST_METADATA_NUMERIC_VALUE,
     ),
@@ -106,7 +113,7 @@ class TestExactMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -164,7 +171,7 @@ class TestPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=(RpcTypeUnaryCall,),
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -221,7 +228,7 @@ class TestSuffixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -278,7 +285,7 @@ class TestPresentMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=(RpcTypeUnaryCall,),
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -337,7 +344,7 @@ class TestInvertMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeUnaryCall, RpcTypeEmptyCall],
+            rpc_types=grpc_testing.RPC_TYPES_BOTH_CALLS,
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -407,7 +414,7 @@ class TestRangeMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeUnaryCall, RpcTypeEmptyCall],
+            rpc_types=grpc_testing.RPC_TYPES_BOTH_CALLS,
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -475,7 +482,7 @@ class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )

--- a/tests/url_map/metadata_filter_test.py
+++ b/tests/url_map/metadata_filter_test.py
@@ -19,14 +19,13 @@ from absl.testing import absltest
 
 from framework import xds_url_map_testcase
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
-RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 
 logger = logging.getLogger(__name__)
@@ -36,7 +35,11 @@ _NUM_RPCS = 150
 _TEST_METADATA_KEY = "xds_md"
 _TEST_METADATA_VALUE_EMPTY = "empty_ytpme"
 _TEST_METADATA = (
-    (RpcTypeEmptyCall, _TEST_METADATA_KEY, _TEST_METADATA_VALUE_EMPTY),
+    (
+        grpc_testing.RPC_TYPE_EMPTY_CALL,
+        _TEST_METADATA_KEY,
+        _TEST_METADATA_VALUE_EMPTY,
+    ),
 )
 match_labels = [
     {"name": "TRAFFICDIRECTOR_NETWORK_NAME", "value": "default-vpc"}
@@ -122,7 +125,7 @@ class TestMetadataFilterMatchAll(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )
@@ -184,7 +187,9 @@ class TestMetadataFilterMatchAny(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(
             _NUM_RPCS, rpc_distribution.unary_call_alternative_service_rpc_count
@@ -244,7 +249,9 @@ class TestMetadataFilterMatchAnyAndAll(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(
             _NUM_RPCS, rpc_distribution.unary_call_alternative_service_rpc_count
@@ -325,7 +332,7 @@ class TestMetadataFilterMatchMultipleRules(
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeEmptyCall],
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
             metadata=_TEST_METADATA,
             num_rpcs=_NUM_RPCS,
         )

--- a/tests/url_map/path_matching_test.py
+++ b/tests/url_map/path_matching_test.py
@@ -20,14 +20,13 @@ from absl.testing import absltest
 from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
-RpcTypeEmptyCall = xds_url_map_testcase.RpcTypeEmptyCall
 XdsTestClient = client_app.XdsTestClient
 _Lang = skips.Lang
 
@@ -73,7 +72,9 @@ class TestFullPathMatchEmptyCall(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
-            test_client, rpc_types=[RpcTypeEmptyCall], num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(
             _NUM_RPCS, rpc_distribution.empty_call_alternative_service_rpc_count
@@ -110,7 +111,9 @@ class TestFullPathMatchUnaryCall(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(
             _NUM_RPCS, rpc_distribution.unary_call_alternative_service_rpc_count
@@ -165,7 +168,7 @@ class TestTwoRoutesAndPrefixMatch(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
             test_client,
-            rpc_types=[RpcTypeUnaryCall, RpcTypeEmptyCall],
+            rpc_types=grpc_testing.RPC_TYPES_BOTH_CALLS,
             num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(0, rpc_distribution.num_failures)
@@ -213,7 +216,9 @@ class TestRegexMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
-            test_client, rpc_types=(RpcTypeUnaryCall,), num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(
             _NUM_RPCS, rpc_distribution.unary_call_alternative_service_rpc_count
@@ -260,7 +265,9 @@ class TestCaseInsensitiveMatch(xds_url_map_testcase.XdsUrlMapTestCase):
 
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         rpc_distribution = self.configure_and_send(
-            test_client, rpc_types=[RpcTypeEmptyCall], num_rpcs=_NUM_RPCS
+            test_client,
+            rpc_types=(grpc_testing.RPC_TYPE_EMPTY_CALL,),
+            num_rpcs=_NUM_RPCS,
         )
         self.assertEqual(
             _NUM_RPCS, rpc_distribution.empty_call_alternative_service_rpc_count

--- a/tests/url_map/retry_test.py
+++ b/tests/url_map/retry_test.py
@@ -21,13 +21,13 @@ import grpc
 from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.rpc import grpc_csds
+from framework.rpc import grpc_testing
 from framework.test_app import client_app
 
 # Type aliases
 HostRule = xds_url_map_testcase.HostRule
 PathMatcher = xds_url_map_testcase.PathMatcher
 GcpResourceManager = xds_url_map_testcase.GcpResourceManager
-RpcTypeUnaryCall = xds_url_map_testcase.RpcTypeUnaryCall
 XdsTestClient = client_app.XdsTestClient
 ExpectedResult = xds_url_map_testcase.ExpectedResult
 _Lang = skips.Lang
@@ -102,10 +102,10 @@ class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
             test_client,
-            rpc_types=(RpcTypeUnaryCall,),
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
             metadata=[
                 (
-                    RpcTypeUnaryCall,
+                    grpc_testing.RPC_TYPE_UNARY_CALL,
                     _RPC_BEHAVIOR_HEADER_NAME,
                     "succeed-on-retry-attempt-4,error-code-14",
                 )
@@ -116,7 +116,7 @@ class TestRetryUpTo3AttemptsAndFail(xds_url_map_testcase.XdsUrlMapTestCase):
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.UNAVAILABLE,
                     ratio=1,
                 ),
@@ -153,10 +153,10 @@ class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
     def rpc_distribution_validate(self, test_client: XdsTestClient):
         self.configure_and_send(
             test_client,
-            rpc_types=(RpcTypeUnaryCall,),
+            rpc_types=(grpc_testing.RPC_TYPE_UNARY_CALL,),
             metadata=[
                 (
-                    RpcTypeUnaryCall,
+                    grpc_testing.RPC_TYPE_UNARY_CALL,
                     _RPC_BEHAVIOR_HEADER_NAME,
                     "succeed-on-retry-attempt-4,error-code-14",
                 )
@@ -167,7 +167,7 @@ class TestRetryUpTo4AttemptsAndSucceed(xds_url_map_testcase.XdsUrlMapTestCase):
             test_client,
             expected=(
                 ExpectedResult(
-                    rpc_type=RpcTypeUnaryCall,
+                    rpc_type=grpc_testing.RPC_TYPE_UNARY_CALL,
                     status_code=grpc.StatusCode.OK,
                     ratio=1,
                 ),


### PR DESCRIPTION
Some tests incorrectly import `framework.xds_url_map_testcase` to get `UNARY_CALL` , `EMPTY_CALL` constants. This should have never been the case: csds logic and helper should be `framework.rpc.grpc_testing`.

This PR:
1. Moves `xds_url_map_testcase.RpcType*Call` to `grpc_testing.RPC_TYPE_*_CALL`.
2. Adds `configure_unary`, `configure_empty`, `configure_rpc_type` helpers to XdsUpdateClientConfigureServiceClient.
3. Adds `RPC_TYPES_BOTH_CALLS` constant import to simplify method calls where both call types are expected.
4. Updates all tests to import constants directly from `grpc_testing`.

Similar to https://github.com/grpc/psm-interop/pull/47.