### PR TITLE
Improve port forwarding logging

### DIFF
--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -1019,13 +1019,20 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         local_port: Optional[int] = None,
         local_address: Optional[str] = None,
     ) -> k8s_port_forwarder.PortForwarder:
-        pf = k8s_port_forwarder.PortForwarder(
-            self._api.context,
-            self.name,
-            f"pod/{pod.metadata.name}",
+        destination = f"pod/{pod.metadata.name}"
+        logger.info(
+            "LOCAL DEV MODE: Enabling port forwarding to %s %s:%s",
+            destination,
+            pod.status.pod_ip,
             remote_port,
-            local_port,
-            local_address,
+        )
+        pf = k8s_port_forwarder.PortForwarder(
+            context=self._api.context,
+            namespace=self.name,
+            destination=destination,
+            remote_port=remote_port,
+            local_port=local_port,
+            local_address=local_address,
         )
         pf.connect()
         return pf

--- a/framework/infrastructure/k8s_internal/k8s_port_forwarder.py
+++ b/framework/infrastructure/k8s_internal/k8s_port_forwarder.py
@@ -123,11 +123,18 @@ class PortForwarder:
 
     def close(self) -> None:
         if self.subprocess is not None:
-            logger.info(
-                "Shutting down port forwarding, pid %s", self.subprocess.pid
-            )
+            logger.info("Shutting down %s", self)
             self.subprocess.kill()
             stdout, _ = self.subprocess.communicate(timeout=5)
-            logger.info("Port forwarding stopped")
-            logger.debug("Port forwarding remaining stdout: %s", stdout)
+            logger.debug(
+                "Port forwarding stopped. Remaining stdout: %s", stdout
+            )
             self.subprocess = None
+
+    def __str__(self):
+        return (
+            f"PortForwarder(pid='{self.subprocess.pid}',"
+            f" namespace='{self.namespace}',"
+            f" destination='{self.destination}',"
+            f" '{self.local_address}:{self.local_port} -> {self.remote_port}')"
+        )

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -193,12 +193,14 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         self.maybe_stop_logging()
 
         # Stop port forwarders if any.
-        if self.pod_port_forwarders:
-            for pod_port_forwarder in self.pod_port_forwarders:
-                pod_port_forwarder.close()
+        for pod_port_forwarder in self.pod_port_forwarders:
+            pod_port_forwarder.close()
 
-            ns = self.k8s_namespace.name if self.k8s_namespace else "Unknown"
-            logger.info("Port forwarders in namespace %s stopped.", ns)
+        if self.pod_port_forwarders:
+            logger.info(
+                "Port forwarders in namespace %s stopped.",
+                self.k8s_namespace.name if self.k8s_namespace else "Unknown",
+            )
 
         self.pod_port_forwarders = []
 


### PR DESCRIPTION
Makes it more clear to what pod port forwarding started - both when starting and shutting down port forwarding.

Starting:
```
I0304 15:00:51.754341 140704470529984 k8s.py:1023] LOCAL DEV MODE: Enabling port forwarding to pod/psm-grpc-server-79cdbdddc7-w668w 10.118.1.122:8080
I0304 15:00:52.664326 140704470529984 k8s_port_forwarder.py:118] Forwarding from 127.0.0.1:61903 -> 8080
```

Shutting down:
```
I0304 15:04:21.526046 140704470529984 k8s_port_forwarder.py:126] Shutting down PortForwarder(pid='58289', namespace='sergiitk-server-20240304-2300-1db6t', destination='pod/psm-grpc-server-79cdbdddc7-w668w', '127.0.0.1:61903 -> 8080')
I0304 15:04:21.529421 140704470529984 k8s_base_runner.py:201] Port forwarders in namespace sergiitk-server-20240304-2300-1db6t stopped.
```