### PR TITLE
Kubernetes templating refactor

### DIFF
--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -18,10 +18,12 @@ from abc import ABCMeta
 import contextlib
 import dataclasses
 import datetime
+import functools
 import logging
 import pathlib
 from typing import List, Optional
 
+import mako.lookup
 import mako.template
 import yaml
 
@@ -233,11 +235,6 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         return total_restart
 
     @classmethod
-    def _render_template(cls, template_file, **kwargs):
-        template = mako.template.Template(filename=str(template_file))
-        return template.render(**kwargs)
-
-    @classmethod
     def _manifests_from_yaml_file(cls, yaml_file):
         with open(yaml_file) as f:
             with contextlib.closing(yaml.safe_load_all(f)) as yml:
@@ -250,12 +247,30 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
             for manifest in yml:
                 yield manifest
 
+    def _render_template(self, template_file: str, **kwargs):
+        template = self._template_lookup.get_template(template_file)
+        return template.render(**kwargs)
+
     @classmethod
-    def _template_file_from_name(cls, template_name):
+    @property
+    @functools.cache
+    def _template_lookup(cls) -> mako.lookup.TemplateLookup:
+        return mako.lookup.TemplateLookup(
+            directories=(str(cls.template_root_path),),
+            input_encoding="utf-8",
+            output_encoding="utf-8",
+            encoding_errors="replace",
+            filesystem_checks=False,
+        )
+
+    @classmethod
+    @property
+    @functools.cache
+    def template_root_path(cls) -> pathlib.Path:
         templates_path = (
             pathlib.Path(__file__).parent / cls.TEMPLATE_DIR_RELATIVE_PATH
         )
-        return templates_path.joinpath(template_name).resolve()
+        return templates_path.resolve()
 
     def _create_from_template(
         self,
@@ -264,10 +279,10 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         custom_object: bool = False,
         **kwargs,
     ) -> object:
-        template_file = self._template_file_from_name(template_name)
+        template_file = self.template_root_path / template_name
         logger.debug("Loading k8s manifest template: %s", template_file)
 
-        yaml_doc = self._render_template(template_file, **kwargs)
+        yaml_doc = self._render_template(template_name, **kwargs)
         logger.info(
             "Rendered template %s/%s:\n%s",
             self.TEMPLATE_DIR_NAME,

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -247,9 +247,9 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
             for manifest in yml:
                 yield manifest
 
-    def _render_template(self, template_file: str, **kwargs):
-        template = self._template_lookup.get_template(template_file)
-        return template.render(**kwargs)
+    def _render_template(self, template_name: str, **template_vars):
+        template = self._template_lookup.get_template(template_name)
+        return template.render(**template_vars)
 
     @classmethod
     @property

--- a/kubernetes-manifests/client-secure.deployment.yaml
+++ b/kubernetes-manifests/client-secure.deployment.yaml
@@ -25,45 +25,45 @@ spec:
     spec:
       serviceAccountName: ${service_account_name}
       containers:
-      - name: ${deployment_name}
-        image: ${image_name}
-        imagePullPolicy: Always
-        startupProbe:
-          tcpSocket:
-            port: ${stats_port}
-          periodSeconds: 3
-          ## Extend the number of probes well beyond the duration of the test
-          ## driver waiting for the container to start.
-          failureThreshold: 1000
-        args:
-          - "--server=${server_target}"
-          - "--stats_port=${stats_port}"
-          - "--secure_mode=${secure_mode}"
-          - "--qps=${qps}"
-          - "--rpc=${rpc}"
-          - "--print_response=${print_response}"
-        ports:
-          - containerPort: ${stats_port}
-        env:
-          - name: GRPC_XDS_BOOTSTRAP
-            value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-          - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-            value: "true"
-          - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
-            value: "true"
-          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-            value: "true"
-        volumeMounts:
-          - mountPath: /tmp/grpc-xds/
-            name: grpc-td-conf
-            readOnly: true
-        resources:
-          limits:
-            cpu: 800m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 512Mi
+        - name: ${deployment_name}
+          image: ${image_name}
+          imagePullPolicy: Always
+          startupProbe:
+            tcpSocket:
+              port: ${stats_port}
+            periodSeconds: 3
+            ## Extend the number of probes well beyond the duration of the test
+            ## driver waiting for the container to start.
+            failureThreshold: 1000
+          args:
+            - "--server=${server_target}"
+            - "--stats_port=${stats_port}"
+            - "--secure_mode=${secure_mode}"
+            - "--qps=${qps}"
+            - "--rpc=${rpc}"
+            - "--print_response=${print_response}"
+          ports:
+            - containerPort: ${stats_port}
+          env:
+            - name: GRPC_XDS_BOOTSTRAP
+              value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
+            - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
+              value: "true"
+            - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
+              value: "true"
+            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+              value: "true"
+          volumeMounts:
+            - mountPath: /tmp/grpc-xds/
+              name: grpc-td-conf
+              readOnly: true
+          resources:
+            limits:
+              cpu: 800m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
       initContainers:
         - name: grpc-td-init
           image: ${td_bootstrap_image}

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -25,78 +25,78 @@ spec:
       serviceAccountName: ${service_account_name}
       % endif
       containers:
-      - name: ${deployment_name}
-        image: ${image_name}
-        imagePullPolicy: Always
-        startupProbe:
-          tcpSocket:
-            port: ${stats_port}
-          periodSeconds: 3
-          ## Extend the number of probes well beyond the duration of the test
-          ## driver waiting for the container to start.
-          failureThreshold: 1000
-        args:
-          - "--server=${server_target}"
-          - "--stats_port=${stats_port}"
-          - "--qps=${qps}"
-          - "--rpc=${rpc}"
-          - "--metadata=${metadata}"
-          % if request_payload_size > 0:
-          - "--request_payload_size=${request_payload_size}"
-          % endif
-          % if response_payload_size > 0:
-          - "--response_payload_size=${response_payload_size}"
-          % endif
-          - "--print_response=${print_response}"
-          % if enable_csm_observability:
-          - "--enable_csm_observability"
-          % endif
-        ports:
-          - containerPort: ${stats_port}
-        env:
-          - name: GRPC_XDS_BOOTSTRAP
-            value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-          - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH
-            value: "true"
-          - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY
-            value: "true"
-          - name: GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION
-            value: "true"
-          - name: GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG
-            value: "true"
-          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-            value: "true"
-          % if csm_workload_name:
-          - name: CSM_WORKLOAD_NAME
-            value: ${csm_workload_name}
-          % endif
-          % if csm_canonical_service_name:
-          - name: CSM_CANONICAL_SERVICE_NAME
-            value: ${csm_canonical_service_name}
-          % endif
-          % if enable_csm_observability:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: NAMESPACE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
-          % endif
-        volumeMounts:
-          - mountPath: /tmp/grpc-xds/
-            name: grpc-td-conf
-            readOnly: true
-        resources:
-          limits:
-            cpu: 800m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 512Mi
+        - name: ${deployment_name}
+          image: ${image_name}
+          imagePullPolicy: Always
+          startupProbe:
+            tcpSocket:
+              port: ${stats_port}
+            periodSeconds: 3
+            ## Extend the number of probes well beyond the duration of the test
+            ## driver waiting for the container to start.
+            failureThreshold: 1000
+          args:
+            - "--server=${server_target}"
+            - "--stats_port=${stats_port}"
+            - "--qps=${qps}"
+            - "--rpc=${rpc}"
+            - "--metadata=${metadata}"
+            % if request_payload_size > 0:
+            - "--request_payload_size=${request_payload_size}"
+            % endif
+            % if response_payload_size > 0:
+            - "--response_payload_size=${response_payload_size}"
+            % endif
+            - "--print_response=${print_response}"
+            % if enable_csm_observability:
+            - "--enable_csm_observability"
+            % endif
+          ports:
+            - containerPort: ${stats_port}
+          env:
+            - name: GRPC_XDS_BOOTSTRAP
+              value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
+            - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH
+              value: "true"
+            - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY
+              value: "true"
+            - name: GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION
+              value: "true"
+            - name: GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG
+              value: "true"
+            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+              value: "true"
+            % if csm_workload_name:
+            - name: CSM_WORKLOAD_NAME
+              value: ${csm_workload_name}
+            % endif
+            % if csm_canonical_service_name:
+            - name: CSM_CANONICAL_SERVICE_NAME
+              value: ${csm_canonical_service_name}
+            % endif
+            % if enable_csm_observability:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+            % endif
+          volumeMounts:
+            - mountPath: /tmp/grpc-xds/
+              name: grpc-td-conf
+              readOnly: true
+          resources:
+            limits:
+              cpu: 800m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
       initContainers:
         - name: grpc-td-init
           image: ${td_bootstrap_image}

--- a/kubernetes-manifests/server-secure.deployment.yaml
+++ b/kubernetes-manifests/server-secure.deployment.yaml
@@ -25,48 +25,48 @@ spec:
     spec:
       serviceAccountName: ${service_account_name}
       containers:
-      - name: ${deployment_name}
-        image: ${image_name}
-        imagePullPolicy: Always
-        startupProbe:
-          tcpSocket:
-            port: ${maintenance_port}
-          periodSeconds: 3
-          ## Extend the number of probes well beyond the duration of the test
-          ## driver waiting for the container to start.
-          failureThreshold: 1000
-        args:
-          - "--port=${test_port}"
-          - "--maintenance_port=${maintenance_port}"
-          - "--secure_mode=${secure_mode}"
-        ports:
-          - containerPort: ${test_port}
-          - containerPort: ${maintenance_port}
-        env:
-          - name: GRPC_XDS_BOOTSTRAP
-            value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-          - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-            value: "true"
-          - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
-            value: "true"
-          ## TODO(sergiitk): this should be conditional for if version < v1.37.x
-          - name: GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API
-            value: "true"
-          - name: GRPC_XDS_EXPERIMENTAL_RBAC
-            value: "true"
-          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-            value: "true"
-        volumeMounts:
-          - mountPath: /tmp/grpc-xds/
-            name: grpc-td-conf
-            readOnly: true
-        resources:
-          limits:
-            cpu: 800m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 512Mi
+        - name: ${deployment_name}
+          image: ${image_name}
+          imagePullPolicy: Always
+          startupProbe:
+            tcpSocket:
+              port: ${maintenance_port}
+            periodSeconds: 3
+            ## Extend the number of probes well beyond the duration of the test
+            ## driver waiting for the container to start.
+            failureThreshold: 1000
+          args:
+            - "--port=${test_port}"
+            - "--maintenance_port=${maintenance_port}"
+            - "--secure_mode=${secure_mode}"
+          ports:
+            - containerPort: ${test_port}
+            - containerPort: ${maintenance_port}
+          env:
+            - name: GRPC_XDS_BOOTSTRAP
+              value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
+            - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
+              value: "true"
+            - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
+              value: "true"
+            ## TODO(sergiitk): this should be conditional for if version < v1.37.x
+            - name: GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API
+              value: "true"
+            - name: GRPC_XDS_EXPERIMENTAL_RBAC
+              value: "true"
+            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+              value: "true"
+          volumeMounts:
+            - mountPath: /tmp/grpc-xds/
+              name: grpc-td-conf
+              readOnly: true
+          resources:
+            limits:
+              cpu: 800m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
       initContainers:
         - name: grpc-td-init
           image: ${td_bootstrap_image}

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -28,67 +28,67 @@ spec:
       terminationGracePeriodSeconds: ${termination_grace_period_seconds}
       % endif
       containers:
-      - name: ${deployment_name}
-        image: ${image_name}
-        imagePullPolicy: Always
-        startupProbe:
-          tcpSocket:
-            port: ${test_port}
-          periodSeconds: 3
-          ## Extend the number of probes well beyond the duration of the test
-          ## driver waiting for the container to start.
-          failureThreshold: 1000
-        args:
-          - "--port=${test_port}"
-          % if enable_csm_observability:
-          - "--enable_csm_observability"
+        - name: ${deployment_name}
+          image: ${image_name}
+          imagePullPolicy: Always
+          startupProbe:
+            tcpSocket:
+              port: ${test_port}
+            periodSeconds: 3
+            ## Extend the number of probes well beyond the duration of the test
+            ## driver waiting for the container to start.
+            failureThreshold: 1000
+          args:
+            - "--port=${test_port}"
+            % if enable_csm_observability:
+            - "--enable_csm_observability"
+            % endif
+          ports:
+            - containerPort: ${test_port}
+          env:
+            - name: GRPC_XDS_BOOTSTRAP
+              value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
+            - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
+              value: "true"
+            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
+              value: "true"
+            % if csm_workload_name:
+            - name: CSM_WORKLOAD_NAME
+              value: ${csm_workload_name}
+            % endif
+            % if csm_canonical_service_name:
+            - name: CSM_CANONICAL_SERVICE_NAME
+              value: ${csm_canonical_service_name}
+            % endif
+            % if enable_csm_observability:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+            % endif
+          volumeMounts:
+            - mountPath: /tmp/grpc-xds/
+              name: grpc-td-conf
+              readOnly: true
+          resources:
+            limits:
+              cpu: 800m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          % if pre_stop_hook:
+          lifecycle:
+            preStop:
+              exec:
+                command: ["tail", "-f", "/dev/null"]
           % endif
-        ports:
-          - containerPort: ${test_port}
-        env:
-          - name: GRPC_XDS_BOOTSTRAP
-            value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-          - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
-            value: "true"
-          - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-            value: "true"
-          % if csm_workload_name:
-          - name: CSM_WORKLOAD_NAME
-            value: ${csm_workload_name}
-          % endif
-          % if csm_canonical_service_name:
-          - name: CSM_CANONICAL_SERVICE_NAME
-            value: ${csm_canonical_service_name}
-          % endif
-          % if enable_csm_observability:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: NAMESPACE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
-          % endif
-        volumeMounts:
-          - mountPath: /tmp/grpc-xds/
-            name: grpc-td-conf
-            readOnly: true
-        resources:
-          limits:
-            cpu: 800m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 512Mi
-        % if pre_stop_hook:
-        lifecycle:
-          preStop:
-            exec:
-              command: ["tail", "-f", "/dev/null"] 
-        % endif
       initContainers:
         - name: grpc-td-init
           image: ${td_bootstrap_image}


### PR DESCRIPTION
This does two things:

1. Uses mako's TemplateLookup to improve rendering performance, and support template includes via `namespace` tag
2. In all deployment templates, aligns deployment's `containers` list with `initContainers`

Both items will be needed for the draining test #34:
1. Will use namespace tag.
2. Will make the diff much more readable because containers and initContainers already indented to the same level.