### PR TITLE
Fix incorrect dependency on xds_url_map_testcase for RpcDistributionStats

### DIFF
--- a/framework/rpc/grpc_testing.py
+++ b/framework/rpc/grpc_testing.py
@@ -78,6 +78,7 @@ class RpcDistributionStats:
     empty_call_alternative_service_rpc_count: int
 
     def __init__(self, lb_stats_dict: LbStatsDict):
+        # TODO(sergiitk): Make raw private when all logic that uses it removed.
         self.raw = lb_stats_dict
 
         self.num_failures = lb_stats_dict.get("numFailures", 0)

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -24,7 +24,6 @@ import unittest
 
 from absl import flags
 from absl import logging
-from google.protobuf import json_format
 import grpc
 
 from framework import xds_k8s_testcase
@@ -61,9 +60,6 @@ HostRule = xds_url_map_test_resources.HostRule
 PathMatcher = xds_url_map_test_resources.PathMatcher
 _KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
 _timedelta = datetime.timedelta
-
-# TODO(sergiitk): should not be here! Move all usages to grpc_testing.
-RpcDistributionStats = grpc_testing.RpcDistributionStats
 
 
 def _split_camel(s: str, delimiter: str = "-") -> str:
@@ -370,7 +366,7 @@ class XdsUrlMapTestCase(
         metadata: Optional[grpc_testing.ConfigureMetadata] = None,
         app_timeout: Optional[int] = None,
         num_rpcs: int,
-    ) -> RpcDistributionStats:
+    ) -> grpc_testing.RpcDistributionStats:
         test_client.update_config.configure(
             rpc_types=rpc_types, metadata=metadata, app_timeout=app_timeout
         )
@@ -382,7 +378,7 @@ class XdsUrlMapTestCase(
             test_client.hostname,
             helpers_grpc.lb_stats_pretty(lb_stats),
         )
-        return RpcDistributionStats(json_format.MessageToDict(lb_stats))
+        return grpc_testing.RpcDistributionStats.from_message(lb_stats)
 
     def assertNumEndpoints(
         self,

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -60,8 +60,10 @@ GcpResourceManager = xds_url_map_test_resources.GcpResourceManager
 HostRule = xds_url_map_test_resources.HostRule
 PathMatcher = xds_url_map_test_resources.PathMatcher
 _KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
-JsonType = Any
 _timedelta = datetime.timedelta
+
+# TODO(sergiitk): should not be here! Move all usages to grpc_testing.
+RpcDistributionStats = grpc_testing.RpcDistributionStats
 
 
 def _split_camel(s: str, delimiter: str = "-") -> str:
@@ -69,65 +71,6 @@ def _split_camel(s: str, delimiter: str = "-") -> str:
     return "".join(
         delimiter + c.lower() if c.isupper() else c for c in s
     ).lstrip(delimiter)
-
-
-class RpcDistributionStats:
-    """A convenience class to check RPC distribution.
-
-    Feel free to add more pre-compute fields.
-    """
-
-    num_failures: int
-    num_oks: int
-    default_service_rpc_count: int
-    alternative_service_rpc_count: int
-    unary_call_default_service_rpc_count: int
-    empty_call_default_service_rpc_count: int
-    unary_call_alternative_service_rpc_count: int
-    empty_call_alternative_service_rpc_count: int
-
-    def __init__(self, json_lb_stats: JsonType):
-        self.num_failures = json_lb_stats.get("numFailures", 0)
-
-        self.num_peers = 0
-        self.num_oks = 0
-        self.default_service_rpc_count = 0
-        self.alternative_service_rpc_count = 0
-        self.unary_call_default_service_rpc_count = 0
-        self.empty_call_default_service_rpc_count = 0
-        self.unary_call_alternative_service_rpc_count = 0
-        self.empty_call_alternative_service_rpc_count = 0
-        self.raw = json_lb_stats
-
-        if "rpcsByPeer" in json_lb_stats:
-            self.num_peers = len(json_lb_stats["rpcsByPeer"])
-        if "rpcsByMethod" in json_lb_stats:
-            for rpc_type in json_lb_stats["rpcsByMethod"]:
-                for peer in json_lb_stats["rpcsByMethod"][rpc_type][
-                    "rpcsByPeer"
-                ]:
-                    count = json_lb_stats["rpcsByMethod"][rpc_type][
-                        "rpcsByPeer"
-                    ][peer]
-                    self.num_oks += count
-                    if rpc_type == "UnaryCall":
-                        if "alternative" in peer:
-                            self.unary_call_alternative_service_rpc_count = (
-                                count
-                            )
-                            self.alternative_service_rpc_count += count
-                        else:
-                            self.unary_call_default_service_rpc_count = count
-                            self.default_service_rpc_count += count
-                    else:
-                        if "alternative" in peer:
-                            self.empty_call_alternative_service_rpc_count = (
-                                count
-                            )
-                            self.alternative_service_rpc_count += count
-                        else:
-                            self.empty_call_default_service_rpc_count = count
-                            self.default_service_rpc_count += count
 
 
 @dataclass

--- a/tests/affinity_test.py
+++ b/tests/affinity_test.py
@@ -17,13 +17,12 @@ from typing import List
 
 from absl import flags
 from absl.testing import absltest
-from google.protobuf import json_format
 
 from framework import xds_k8s_flags
 from framework import xds_k8s_testcase
-from framework import xds_url_map_testcase
 from framework.helpers import skips
 from framework.rpc import grpc_channelz
+from framework.rpc import grpc_testing
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)
@@ -121,9 +120,8 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
         with self.subTest("10_first_100_affinity_rpcs_pick_same_backend"):
             rpc_stats = self.getClientRpcStats(test_client, _RPC_COUNT)
-            json_lb_stats = json_format.MessageToDict(rpc_stats)
-            rpc_distribution = xds_url_map_testcase.RpcDistributionStats(
-                json_lb_stats
+            rpc_distribution = grpc_testing.RpcDistributionStats.from_message(
+                rpc_stats
             )
             self.assertEqual(1, rpc_distribution.num_peers)
 
@@ -182,9 +180,8 @@ class AffinityTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
         with self.subTest("12_next_100_affinity_rpcs_pick_different_backend"):
             rpc_stats = self.getClientRpcStats(test_client, _RPC_COUNT)
-            json_lb_stats = json_format.MessageToDict(rpc_stats)
-            rpc_distribution = xds_url_map_testcase.RpcDistributionStats(
-                json_lb_stats
+            rpc_distribution = grpc_testing.RpcDistributionStats.from_message(
+                rpc_stats
             )
             self.assertEqual(1, rpc_distribution.num_peers)
             new_backend_inuse = list(rpc_distribution.raw["rpcsByPeer"].keys())[


### PR DESCRIPTION
Same as #47, #48, but for `RpcDistributionStats`.

This concludes the fix for xds_url_map_testcase dependency; after this change only url_map tests depend on it.