### PR TITLE
Improve metadatas_by_peer pretty-print

### DIFF
--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -12,19 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This contains common helpers for working with grpc data structures."""
+import collections
 import dataclasses
 import functools
-from typing import Dict, List, Optional
+from typing import Optional
 
 import grpc
+from typing_extensions import TypeAlias
 import yaml
 
 from framework.rpc import grpc_testing
 
 # Type aliases
-RpcsByPeer: Dict[str, int]
-RpcMetadata = grpc_testing.LoadBalancerStatsResponse.RpcMetadata
-MetadataByPeer: list[str, RpcMetadata]
+_RpcsByPeerPretty: TypeAlias = dict[str, int]
+_RpcsByMethodPretty: TypeAlias = dict[str, _RpcsByPeerPretty]
+_MetadataByPeerPretty: TypeAlias = dict[str, list[str]]
+_MetadatasByPeerPretty: TypeAlias = dict[str, _MetadataByPeerPretty]
 
 
 @functools.cache
@@ -60,7 +63,7 @@ class PrettyStatsPerMethod:
     #   "(0, OK)": 20,
     #   "(14, UNAVAILABLE)": 10
     # }
-    result: Dict[str, int]
+    result: dict[str, int]
 
     @property
     @functools.cache
@@ -72,7 +75,7 @@ class PrettyStatsPerMethod:
     def from_response(
         method_name: str, method_stats: grpc_testing.MethodStats
     ) -> "PrettyStatsPerMethod":
-        stats: Dict[str, int] = dict()
+        stats: dict[str, int] = dict()
         for status_int, count in method_stats.result.items():
             status: Optional[grpc.StatusCode] = status_from_int(status_int)
             status_formatted = status_pretty(status) if status else "None"
@@ -103,11 +106,9 @@ def accumulated_stats_pretty(
           (14, UNAVAILABLE): 20
     """
     # Only look at stats_per_method, as the other fields are deprecated.
-    result: List[Dict] = []
-    for method_name, method_stats in accumulated_stats.stats_per_method.items():
-        pretty_stats = PrettyStatsPerMethod.from_response(
-            method_name, method_stats
-        )
+    result: list[dict] = []
+    for method, stats in accumulated_stats.stats_per_method.items():
+        pretty_stats = PrettyStatsPerMethod.from_response(method, stats)
         # Skip methods with no RPCs reported when ignore_empty is True.
         if ignore_empty and not pretty_stats.rpcs_started:
             continue
@@ -124,7 +125,7 @@ class PrettyLoadBalancerStats:
     # The number of completed RPCs for each peer.
     # Format: a dictionary from the host name (str) to the RPC count (int), f.e.
     # {"host-a": 10, "host-b": 20}
-    rpcs_by_peer: "RpcsByPeer"
+    rpcs_by_peer: _RpcsByPeerPretty
 
     # The number of completed RPCs per method per each pear.
     # Format: a dictionary from the method name to RpcsByPeer (see above), f.e.:
@@ -132,55 +133,63 @@ class PrettyLoadBalancerStats:
     #   "UNARY_CALL": {"host-a": 10, "host-b": 20},
     #   "EMPTY_CALL": {"host-a": 42},
     # }
-    rpcs_by_method: Dict[str, "RpcsByPeer"]
+    rpcs_by_method: _RpcsByMethodPretty
 
-    metadatas_by_peer: Dict[str, "MetadataByPeer"]
+    metadatas_by_peer: _MetadatasByPeerPretty
 
-    @staticmethod
+    @classmethod
     def _parse_rpcs_by_peer(
-        rpcs_by_peer: grpc_testing.RpcsByPeer,
-    ) -> "RpcsByPeer":
-        result = dict()
+        cls, rpcs_by_peer: grpc_testing.RpcsByPeerMap
+    ) -> _RpcsByPeerPretty:
+        result: _RpcsByPeerPretty = dict()
         for peer, count in rpcs_by_peer.items():
             result[peer] = count
         return result
 
+    @classmethod
+    def _parse_rpcs_by_method(
+        cls, rpcs_by_method: grpc_testing.RpcsByMethod
+    ) -> _RpcsByMethodPretty:
+        result: _RpcsByMethodPretty = dict()
+        for method, stats in rpcs_by_method.items():
+            if stats:
+                result[method] = cls._parse_rpcs_by_peer(stats.rpcs_by_peer)
+        return result
+
     @staticmethod
     def _parse_metadatas_by_peer(
-        metadatas_by_peer: grpc_testing.LoadBalancerStatsResponse.MetadataByPeer,
-    ) -> "MetadataByPeer":
-        result = dict()
-        for peer, metadatas in metadatas_by_peer.items():
-            pretty_metadata = ""
-            for rpc_metadatas in metadatas.rpc_metadata:
-                for metadata in rpc_metadatas.metadata:
-                    pretty_metadata += (
-                        metadata.key + ": " + metadata.value + ", "
-                    )
-            result[peer] = pretty_metadata
-        return result
+        metadatas_by_peer: grpc_testing.MetadatasByPeer,
+    ) -> _MetadatasByPeerPretty:
+        result: _MetadatasByPeerPretty = collections.defaultdict(dict)
+        for peer, metadata_by_peer in metadatas_by_peer.items():
+            for rpc_metadata in metadata_by_peer.rpc_metadata:
+                # Metadata values are repeated all the time, only add unique.
+                uniq_vals: dict[str, set[str]] = collections.defaultdict(set)
+                for metadata in rpc_metadata.metadata:
+                    key: str = metadata.key
+                    if metadata.type == grpc_testing.MetadataType.TRAILING:
+                        key = f"TRAILING_{key}"
+                    uniq_vals[key].add(metadata.value)
+
+                for key, uniq_val in uniq_vals.items():
+                    result[peer][key] = list(uniq_val)
+        return dict(result)
 
     @classmethod
     def from_response(
         cls, lb_stats: grpc_testing.LoadBalancerStatsResponse
     ) -> "PrettyLoadBalancerStats":
-        rpcs_by_method: Dict[str, "RpcsByPeer"] = dict()
-        for method_name, stats in lb_stats.rpcs_by_method.items():
-            if stats:
-                rpcs_by_method[method_name] = cls._parse_rpcs_by_peer(
-                    stats.rpcs_by_peer
-                )
         return PrettyLoadBalancerStats(
             num_failures=lb_stats.num_failures,
             rpcs_by_peer=cls._parse_rpcs_by_peer(lb_stats.rpcs_by_peer),
-            rpcs_by_method=rpcs_by_method,
+            rpcs_by_method=cls._parse_rpcs_by_method(lb_stats.rpcs_by_method),
             metadatas_by_peer=cls._parse_metadatas_by_peer(
                 lb_stats.metadatas_by_peer
             ),
         )
 
 
-def lb_stats_pretty(lb: grpc_testing.LoadBalancerStatsResponse) -> str:
+def lb_stats_pretty(lb_stats: grpc_testing.LoadBalancerStatsResponse) -> str:
     """Pretty print LoadBalancerStatsResponse.
 
     Example:
@@ -194,8 +203,14 @@ def lb_stats_pretty(lb: grpc_testing.LoadBalancerStatsResponse) -> str:
       rpcs_by_peer:
         psm-grpc-server-a: 200
         psm-grpc-server-b: 42
+      metadatas_by_peer:
+        psm-grpc-server-a:
+          cookie: [c1, c2]
+          TRAILING_cookie: [foo]
+        psm-grpc-server-b:
+          cookie: [bar]
     """
-    pretty_lb_stats = PrettyLoadBalancerStats.from_response(lb)
+    pretty_lb_stats = PrettyLoadBalancerStats.from_response(lb_stats)
     stats_as_dict = dataclasses.asdict(pretty_lb_stats)
 
     # Don't print metadatas_by_peer unless it has data

--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -173,6 +173,8 @@ class PrettyLoadBalancerStats:
 
                 for key, uniq_val in uniq_vals.items():
                     result[peer][key] = list(uniq_val)
+        # Converting to a normal dict because dataclasses.asdict() doesn't work
+        # with collections.defaultdict(): https://bugs.python.org/issue35540.
         return dict(result)
 
     @classmethod

--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -130,8 +130,8 @@ class PrettyLoadBalancerStats:
     # The number of completed RPCs per method per each pear.
     # Format: a dictionary from the method name to RpcsByPeer (see above), f.e.:
     # {
-    #   "UNARY_CALL": {"host-a": 10, "host-b": 20},
-    #   "EMPTY_CALL": {"host-a": 42},
+    #   "UnaryCall": {"host-a": 10, "host-b": 20},
+    #   "EmptyCall": {"host-a": 42},
     # }
     rpcs_by_method: _RpcsByMethodPretty
 
@@ -195,10 +195,10 @@ def lb_stats_pretty(lb_stats: grpc_testing.LoadBalancerStatsResponse) -> str:
     Example:
       num_failures: 13
       rpcs_by_method:
-        UNARY_CALL:
+        UnaryCall:
           psm-grpc-server-a: 100
           psm-grpc-server-b: 42
-        EMPTY_CALL:
+        EmptyCall:
           psm-grpc-server-a: 200
       rpcs_by_peer:
         psm-grpc-server-a: 200

--- a/framework/rpc/grpc_testing.py
+++ b/framework/rpc/grpc_testing.py
@@ -39,12 +39,22 @@ MethodStats: TypeAlias = (
     messages_pb2.LoadBalancerAccumulatedStatsResponse.MethodStats
 )
 RpcsByPeer: TypeAlias = messages_pb2.LoadBalancerStatsResponse.RpcsByPeer
+RpcsByPeerMap: TypeAlias = (
+    "messages_pb2.LoadBalancerStatsResponse.RpcsByPeer.rpcs_by_peer"
+)
+RpcsByMethod: TypeAlias = (
+    "messages_pb2.LoadBalancerStatsResponse.rpcs_by_method"
+)
 
 # RPC Metadata
 RpcMetadata: TypeAlias = messages_pb2.LoadBalancerStatsResponse.RpcMetadata
 MetadataByPeer: TypeAlias = (
     messages_pb2.LoadBalancerStatsResponse.MetadataByPeer
 )
+MetadatasByPeer: TypeAlias = (
+    "messages_pb2.LoadBalancerStatsResponse.metadatas_by_peer"
+)
+MetadataType: TypeAlias = messages_pb2.LoadBalancerStatsResponse.MetadataType
 # An argument to XdsUpdateClientConfigureService.Configure.
 # Rpc type name, key, value.
 ConfigureMetadata: TypeAlias = Sequence[tuple[str, str, str]]

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -233,8 +233,16 @@ class XdsKubernetesBaseTestCase(base_testcase.BaseTestCase):
 
     @classmethod
     def _pretty_lb_stats(cls, lb_stats: _LoadBalancerStatsResponse) -> str:
-        stats_yaml = helpers_grpc.lb_stats_pretty(lb_stats)
-        return cls.yaml_highlighter.highlight(stats_yaml)
+        try:
+            stats_yaml = helpers_grpc.lb_stats_pretty(lb_stats)
+            return cls.yaml_highlighter.highlight(stats_yaml)
+        except Exception as e:  # noqa pylint: disable=broad-except
+            logger.warning(
+                "Error printing LoadBalancerStatsResponse %s",
+                lb_stats,
+                exc_info=e,
+            )
+            return str(lb_stats)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
1. Fix incorrect type hints in `_parse_rpcs_by_peer`, `_parse_rpcs_by_method`, `_parse_metadatas_by_peer`
2. Change the structure of `metadatas_by_peer` object, so that it's not repeating each header multiple times. Instead, the structure is `metadatas_by_peer[host][key] = set(unique values seen)`.
3. Parse trailing metadata. Same format as the regular one, but the key is prefixed with `TRAILING_`

### Before
```yaml
num_failures: 0
rpcs_by_peer:
  psm-grpc-server-7c8bf768b6-9tq5p: 10
rpcs_by_method:
  UnaryCall:
    psm-grpc-server-7c8bf768b6-9tq5p: 10
metadatas_by_peer:
  psm-grpc-server-7c8bf768b6-9tq5p: 'hostname: psm-grpc-server-7c8bf768b6-9tq5p, hostname:
    psm-grpc-server-7c8bf768b6-9tq5p, hostname: psm-grpc-server-7c8bf768b6-9tq5p,
    hostname: psm-grpc-server-7c8bf768b6-9tq5p, hostname: psm-grpc-server-7c8bf768b6-9tq5p,
    hostname: psm-grpc-server-7c8bf768b6-9tq5p, hostname: psm-grpc-server-7c8bf768b6-9tq5p,
    hostname: psm-grpc-server-7c8bf768b6-9tq5p, hostname: psm-grpc-server-7c8bf768b6-9tq5p,
    hostname: psm-grpc-server-7c8bf768b6-9tq5p, '
```

### After

```yaml
num_failures: 0
rpcs_by_peer:
  psm-grpc-server-9896d7f8b-fqbx4: 10
rpcs_by_method:
  UnaryCall:
    psm-grpc-server-9896d7f8b-fqbx4: 10
metadatas_by_peer:
  psm-grpc-server-9896d7f8b-fqbx4:
    hostname:
    - psm-grpc-server-9896d7f8b-fqbx4
```

Multiple header values example:

```yaml
num_failures: 0
rpcs_by_peer:
  psm-grpc-server-578c74fb79-wgnwf: 1
rpcs_by_method:
  UnaryCall:
    psm-grpc-server-578c74fb79-wgnwf: 1
metadatas_by_peer:
  psm-grpc-server-578c74fb79-wgnwf:
    hostname:
    - psm-grpc-server-578c74fb79-wgnwf
    set-cookie:
    - GSSA=MTAuMjQuNC4zMTo4MDgwO2Nsb3VkLWludGVybmFsLWlzdGlvOmNsb3VkX21wXzgzMDI5MzI2MzM4NF81OTUzMzE5OTEwODk3Mjk2Nzcz;
      HttpOnly; Path=/; Max-Age=50
```