### PR TITLE
Fix naming convention for gamma resources

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -243,23 +243,24 @@ class GammaServerRunner(KubernetesServerRunner):
 
         return servers
 
-    def create_session_affinity_policy(self, template: str):
+    def create_session_affinity_policy(self, template: str, **template_vars):
         self.session_affinity_policy = self._create_session_affinity_policy(
             template,
             session_affinity_policy_name=self.SESSION_AFFINITY_POLICY_NAME,
             namespace_name=self.k8s_namespace.name,
-            route_name=self.route_name,
-            service_name=self.service_name,
+            **template_vars,
         )
 
     def create_session_affinity_policy_route(self):
         self.create_session_affinity_policy(
-            "gamma/session_affinity_policy_route.yaml"
+            "gamma/session_affinity_policy_route.yaml",
+            route_name=self.route_name,
         )
 
     def create_session_affinity_policy_service(self):
         self.create_session_affinity_policy(
-            "gamma/session_affinity_policy_service.yaml"
+            "gamma/session_affinity_policy_service.yaml",
+            service_name=self.service_name,
         )
 
     def create_session_affinity_filter(self):

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -16,7 +16,7 @@ Run xDS Test Client on Kubernetes using Gamma
 """
 import datetime
 import logging
-from typing import List, Optional
+from typing import Final, List, Optional
 
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s
@@ -35,8 +35,8 @@ class GammaServerRunner(KubernetesServerRunner):
     # Mutable state.
     route: Optional[k8s.GammaHttpRoute] = None
     frontend_service: Optional[k8s.V1Service] = None
-    sa_filter: Optional[k8s.GcpSessionAffinityFilter] = None
-    sa_policy: Optional[k8s.GcpSessionAffinityPolicy] = None
+    session_affinity_filter: Optional[k8s.GcpSessionAffinityFilter] = None
+    session_affinity_policy: Optional[k8s.GcpSessionAffinityPolicy] = None
     backend_policy: Optional[k8s.GcpBackendPolicy] = None
     pod_monitoring: Optional[k8s.PodMonitoring] = None
     pod_monitoring_name: Optional[str] = None
@@ -45,6 +45,10 @@ class GammaServerRunner(KubernetesServerRunner):
     frontend_service_name: str
     csm_workload_name: str
     csm_canonical_service_name: str
+
+    SESSION_AFFINITY_FILTER_NAME: Final[str] = "ssa-filter"
+    SESSION_AFFINITY_POLICY_NAME: Final[str] = "ssa-policy"
+    BACKEND_POLICY_NAME: Final[str] = "backend-policy"
 
     def __init__(
         self,
@@ -71,9 +75,6 @@ class GammaServerRunner(KubernetesServerRunner):
         namespace_template: Optional[str] = None,
         debug_use_port_forwarding: bool = False,
         enable_workload_identity: bool = True,
-        safilter_name: str = "ssa-filter",
-        sapolicy_name: str = "ssa-policy",
-        backend_policy_name: str = "backend-policy",
         csm_workload_name: str = "",
         csm_canonical_service_name: str = "",
         deployment_args: Optional[ServerDeploymentArgs] = None,
@@ -105,9 +106,6 @@ class GammaServerRunner(KubernetesServerRunner):
 
         self.frontend_service_name = frontend_service_name
         self.route_name = route_name or f"route-{deployment_name}"
-        self.safilter_name = safilter_name
-        self.sapolicy_name = sapolicy_name
-        self.backend_policy_name = backend_policy_name
         self.csm_workload_name = csm_workload_name
         self.csm_canonical_service_name = csm_canonical_service_name
 
@@ -246,9 +244,9 @@ class GammaServerRunner(KubernetesServerRunner):
         return servers
 
     def create_session_affinity_policy(self, template: str):
-        self.sa_policy = self._create_session_affinity_policy(
+        self.session_affinity_policy = self._create_session_affinity_policy(
             template,
-            session_affinity_policy_name=self.sapolicy_name,
+            session_affinity_policy_name=self.SESSION_AFFINITY_POLICY_NAME,
             namespace_name=self.k8s_namespace.name,
             route_name=self.route_name,
             service_name=self.service_name,
@@ -265,16 +263,16 @@ class GammaServerRunner(KubernetesServerRunner):
         )
 
     def create_session_affinity_filter(self):
-        self.sa_filter = self._create_session_affinity_filter(
+        self.session_affinity_filter = self._create_session_affinity_filter(
             "gamma/session_affinity_filter.yaml",
-            session_affinity_filter_name=self.safilter_name,
+            session_affinity_filter_name=self.SESSION_AFFINITY_FILTER_NAME,
             namespace_name=self.k8s_namespace.name,
         )
 
-    def createBackendPolicy(self):
-        self.be_policy = self._create_backend_policy(
+    def create_backend_policy(self):
+        self.backend_policy = self._create_backend_policy(
             "gamma/backend_policy.yaml",
-            backend_policy_name=self.backend_policy_name,
+            backend_policy_name=self.BACKEND_POLICY_NAME,
             namespace_name=self.k8s_namespace.name,
             service_name=self.service_name,
         )
@@ -298,16 +296,20 @@ class GammaServerRunner(KubernetesServerRunner):
                 self._delete_deployment(self.deployment_name)
                 self.deployment = None
 
-            if self.sa_policy or force:
-                self._delete_session_affinity_policy(self.sapolicy_name)
-                self.sa_policy = None
+            if self.session_affinity_policy or force:
+                self._delete_session_affinity_policy(
+                    self.SESSION_AFFINITY_POLICY_NAME
+                )
+                self.session_affinity_policy = None
 
-            if self.sa_filter or force:
-                self._delete_session_affinity_filter(self.safilter_name)
-                self.sa_filter = None
+            if self.session_affinity_filter or force:
+                self._delete_session_affinity_filter(
+                    self.SESSION_AFFINITY_FILTER_NAME
+                )
+                self.session_affinity_filter = None
 
             if self.backend_policy or force:
-                self._delete_backend_policy(self.backend_policy_name)
+                self._delete_backend_policy(self.BACKEND_POLICY_NAME)
                 self.backend_policy = None
 
             if self.enable_workload_identity and (

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -74,7 +74,6 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
     # Fields with default values.
     namespace_template: str = "namespace.yaml"
     reuse_namespace: bool = False
-    log_to_stdout: bool = False
 
     # Mutable state. Describes the current run.
     namespace: Optional[k8s.V1Namespace] = None

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -74,6 +74,7 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
     # Fields with default values.
     namespace_template: str = "namespace.yaml"
     reuse_namespace: bool = False
+    log_to_stdout: bool = False
 
     # Mutable state. Describes the current run.
     namespace: Optional[k8s.V1Namespace] = None
@@ -505,114 +506,158 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         )
         return deployment
 
-    def _create_gamma_route(self, template, **kwargs) -> k8s.GammaHttpRoute:
+    def _create_gamma_route(
+        self,
+        template: str,
+        *,
+        route_name: str,
+        namespace_name: str,
+        service_name: str,
+        test_port: int,
+        frontend_service_name: str,
+        **template_vars,
+    ) -> k8s.GammaHttpRoute:
         route = self._create_from_template(
             template,
             custom_object=True,
-            **kwargs,
+            namespace_name=namespace_name,
+            service_name=service_name,
+            test_port=test_port,
+            frontend_service_name=frontend_service_name,
+            **template_vars,
         )
         if not (
             isinstance(route, k8s.GammaHttpRoute) and route.kind == "HTTPRoute"
         ):
             raise _RunnerError(
-                f"Expected ResourceInstance[HTTPRoute] to be created from"
-                f" manifest {template}"
+                f"Expected HTTPRoute to be created from" f" manifest {template}"
             )
-        if route.metadata.name != kwargs["route_name"]:
+        if route.metadata.name != route_name:
             raise _RunnerError(
-                "ResourceInstance[HTTPRoute] created with unexpected name: "
-                f"{route.metadata.name}"
+                "HTTPRoute created with unexpected name:"
+                f" {route.metadata.name}"
             )
         logger.debug(
-            "ResourceInstance[HTTPRoute] %s created at %s",
+            "HTTPRoute %s created at %s",
             route.metadata.name,
             route.metadata.creation_timestamp,
         )
         return route
 
     def _create_session_affinity_policy(
-        self, template, **kwargs
+        self,
+        template: str,
+        *,
+        session_affinity_policy_name: str,
+        namespace_name: str,
+        **template_vars,
     ) -> k8s.GcpSessionAffinityPolicy:
-        saPolicy = self._create_from_template(
+        has_route_name = "route_name" in template_vars
+        has_service_name = "service_name" in template_vars
+        if has_route_name == has_service_name:
+            raise ValueError(
+                "Exactly one of 'route_name', 'service_name' must be set"
+            )
+
+        sa_policy = self._create_from_template(
             template,
             custom_object=True,
-            **kwargs,
+            session_affinity_policy_name=session_affinity_policy_name,
+            namespace_name=namespace_name,
+            **template_vars,
         )
         if not (
-            isinstance(saPolicy, k8s.GcpSessionAffinityPolicy)
-            and saPolicy.kind == "GCPSessionAffinityPolicy"
+            isinstance(sa_policy, k8s.GcpSessionAffinityPolicy)
+            and sa_policy.kind == "GCPSessionAffinityPolicy"
         ):
             raise _RunnerError(
-                f"Expected ResourceInstance[GCPSessionAffinityPolicy] to be"
+                f"Expected GCPSessionAffinityPolicy to be"
                 f" created from manifest {template}"
             )
-        if saPolicy.metadata.name != kwargs["session_affinity_policy_name"]:
+        if sa_policy.metadata.name != session_affinity_policy_name:
             raise _RunnerError(
-                "ResourceInstance[GCPSessionAffinityPolicy] created with"
-                f" unexpected name: {saPolicy.metadata.name}"
+                "GCPSessionAffinityPolicy created with"
+                f" unexpected name: {sa_policy.metadata.name}"
             )
         logger.debug(
-            "ResourceInstance[GCPSessionAffinityPolicy] %s created at %s",
-            saPolicy.metadata.name,
-            saPolicy.metadata.creation_timestamp,
+            "GCPSessionAffinityPolicy %s created at %s",
+            sa_policy.metadata.name,
+            sa_policy.metadata.creation_timestamp,
         )
-        return saPolicy
+        return sa_policy
 
     def _create_session_affinity_filter(
-        self, template, **kwargs
+        self,
+        template: str,
+        *,
+        session_affinity_filter_name: str,
+        namespace_name: str,
+        **template_vars,
     ) -> k8s.GcpSessionAffinityFilter:
-        saFilter = self._create_from_template(
+        sa_filter = self._create_from_template(
             template,
             custom_object=True,
-            **kwargs,
+            namespace_name=namespace_name,
+            session_affinity_filter_name=session_affinity_filter_name,
+            **template_vars,
         )
         if not (
-            isinstance(saFilter, k8s.GcpSessionAffinityFilter)
-            and saFilter.kind == "GCPSessionAffinityFilter"
+            isinstance(sa_filter, k8s.GcpSessionAffinityFilter)
+            and sa_filter.kind == "GCPSessionAffinityFilter"
         ):
             raise _RunnerError(
-                f"Expected ResourceInstance[GCPSessionAffinityFilter] to be"
+                f"Expected GCPSessionAffinityFilter to be"
                 f" created from manifest {template}"
             )
-        if saFilter.metadata.name != kwargs["session_affinity_filter_name"]:
+        if sa_filter.metadata.name != session_affinity_filter_name:
             raise _RunnerError(
-                "ResourceInstance[GCPSessionAffinityFilter] created with"
-                f" unexpected name: {saFilter.metadata.name}"
+                "GCPSessionAffinityFilter created with"
+                f" unexpected name: {sa_filter.metadata.name}"
             )
         logger.debug(
-            "ResourceInstance[GCPSessionAffinityFilter] %s created at %s",
-            saFilter.metadata.name,
-            saFilter.metadata.creation_timestamp,
+            "GCPSessionAffinityFilter %s created at %s",
+            sa_filter.metadata.name,
+            sa_filter.metadata.creation_timestamp,
         )
-        return saFilter
+        return sa_filter
 
     def _create_backend_policy(
-        self, template, **kwargs
+        self,
+        template: str,
+        *,
+        backend_policy_name: str,
+        namespace_name: str,
+        service_name: str,
+        **template_vars,
     ) -> k8s.GcpBackendPolicy:
-        be_policy = self._create_from_template(
+        # TODO(sergiitk): explicit vars.
+        backend_policy = self._create_from_template(
             template,
             custom_object=True,
-            **kwargs,
+            backend_policy_name=backend_policy_name,
+            namespace_name=namespace_name,
+            service_name=service_name,
+            **template_vars,
         )
         if not (
-            isinstance(be_policy, k8s.GcpBackendPolicy)
-            and be_policy.kind == "GCPBackendPolicy"
+            isinstance(backend_policy, k8s.GcpBackendPolicy)
+            and backend_policy.kind == "GCPBackendPolicy"
         ):
             raise _RunnerError(
-                f"Expected ResourceInstance[GCPBackendPolicy] to be"
-                f" created from manifest {template}"
+                "Expected GCPBackendPolicy to be created from manifest"
+                " {template}"
             )
-        if be_policy.metadata.name != kwargs["be_policy_name"]:
+        if backend_policy.metadata.name != backend_policy_name:
             raise _RunnerError(
-                "ResourceInstance[GCPBackendPolicy] created with"
-                f" unexpected name: {be_policy.metadata.name}"
+                "GCPBackendPolicy created with unexpected name:"
+                f" {backend_policy.metadata.name}"
             )
         logger.debug(
-            "ResourceInstance[GCPBackendPolicy] %s created at %s",
-            be_policy.metadata.name,
-            be_policy.metadata.creation_timestamp,
+            "GCPBackendPolicy %s created at %s",
+            backend_policy.metadata.name,
+            backend_policy.metadata.creation_timestamp,
         )
-        return be_policy
+        return backend_policy
 
     def _create_service(self, template, **kwargs) -> k8s.V1Service:
         service = self._create_from_template(template, **kwargs)

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -519,6 +519,7 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         route = self._create_from_template(
             template,
             custom_object=True,
+            route_name=route_name,
             namespace_name=namespace_name,
             service_name=service_name,
             test_port=test_port,
@@ -596,8 +597,8 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
         sa_filter = self._create_from_template(
             template,
             custom_object=True,
-            namespace_name=namespace_name,
             session_affinity_filter_name=session_affinity_filter_name,
+            namespace_name=namespace_name,
             **template_vars,
         )
         if not (

--- a/kubernetes-manifests/gamma/backend_policy.yaml
+++ b/kubernetes-manifests/gamma/backend_policy.yaml
@@ -2,7 +2,7 @@
 kind: GCPBackendPolicy
 apiVersion: networking.gke.io/v1
 metadata:
-  name: ${be_policy_name}
+  name: ${backend_policy_name}
   namespace: ${namespace_name}
   labels:
     owner: xds-k8s-interop-test

--- a/kubernetes-manifests/gamma/frontend_service.yaml
+++ b/kubernetes-manifests/gamma/frontend_service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:           
   name: ${service_name}
   namespace: ${namespace_name}
+  labels:
+    owner: xds-k8s-interop-test
 spec:                   
   ports:      
   - port: 8080

--- a/kubernetes-manifests/gamma/session_affinity_filter.yaml
+++ b/kubernetes-manifests/gamma/session_affinity_filter.yaml
@@ -4,6 +4,8 @@ kind: GCPSessionAffinityFilter
 metadata:
   name: ${session_affinity_filter_name}
   namespace: ${namespace_name}
+  labels:
+    owner: xds-k8s-interop-test
 spec:
   statefulGeneratedCookie:
     cookieTtlSeconds: 50

--- a/kubernetes-manifests/gamma/session_affinity_policy_route.yaml
+++ b/kubernetes-manifests/gamma/session_affinity_policy_route.yaml
@@ -4,6 +4,8 @@ kind: GCPSessionAffinityPolicy
 metadata:
   name: ${session_affinity_policy_name}
   namespace: ${namespace_name}
+  labels:
+    owner: xds-k8s-interop-test
 spec:
   statefulGeneratedCookie:
     cookieTtlSeconds: 50

--- a/kubernetes-manifests/gamma/session_affinity_policy_service.yaml
+++ b/kubernetes-manifests/gamma/session_affinity_policy_service.yaml
@@ -4,6 +4,8 @@ kind: GCPSessionAffinityPolicy
 metadata:
   name: ${session_affinity_policy_name}
   namespace: ${namespace_name}
+  labels:
+    owner: xds-k8s-interop-test
 spec:
   statefulGeneratedCookie:
     cookieTtlSeconds: 50

--- a/tests/gamma/affinity_test.py
+++ b/tests/gamma/affinity_test.py
@@ -32,11 +32,6 @@ _XdsTestClient = client_app.XdsTestClient
 
 _REPLICA_COUNT = 3
 
-# TODO(rbellevi): set this property on the prestop hook test class
-# We never actually hit this timeout under normal circumstances, so this large
-# value is acceptable.
-# termination_grace_period_seconds: int = 600
-
 
 class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     def getClientRpcStats(
@@ -62,7 +57,7 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             )
 
         with self.subTest("02_create_ssa_filter"):
-            self.server_runner.createSessionAffinityFilter()
+            self.server_runner.create_session_affinity_filter()
 
         # Default is round robin LB policy.
 
@@ -93,9 +88,7 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             test_servers = self.startTestServers(replica_count=_REPLICA_COUNT)
 
         with self.subTest("02_create_ssa_policy"):
-            self.server_runner.createSessionAffinityPolicy(
-                "gamma/session_affinity_policy_route.yaml"
-            )
+            self.server_runner.create_session_affinity_policy_route()
 
         # Default is round robin LB policy.
 
@@ -126,9 +119,7 @@ class AffinityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             test_servers = self.startTestServers(replica_count=_REPLICA_COUNT)
 
         with self.subTest("02_create_ssa_policy"):
-            self.server_runner.createSessionAffinityPolicy(
-                "gamma/session_affinity_policy_service.yaml"
-            )
+            self.server_runner.create_session_affinity_policy_service()
 
         # Default is round robin LB policy.
 


### PR DESCRIPTION
1. Fix camelCase method names and variables
2. Move SSA resource names to class  constants
3. Explicit arguments in `_create_gamma_route` and `_create_*` SSA resources
4. Add missing `owner` label to SSA manifests