### PR TITLE
Speed up CSM namespace deletion by 150%

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -293,22 +293,6 @@ class GammaServerRunner(KubernetesServerRunner):
     @override
     def cleanup(self, *, force=False, force_namespace=False):
         try:
-            if self.route or force:
-                self._delete_gamma_route(self.route_name)
-                self.route = None
-
-            if self.frontend_service or force:
-                self._delete_service(self.frontend_service_name)
-                self.frontend_service = None
-
-            if (self.service and not self.reuse_service) or force:
-                self._delete_service(self.service_name)
-                self.service = None
-
-            if self.deployment or force:
-                self._delete_deployment(self.deployment_name)
-                self.deployment = None
-
             if self.session_affinity_policy or force:
                 self._delete_session_affinity_policy(
                     self.SESSION_AFFINITY_POLICY_NAME
@@ -324,6 +308,22 @@ class GammaServerRunner(KubernetesServerRunner):
             if self.backend_policy or force:
                 self._delete_backend_policy(self.BACKEND_POLICY_NAME)
                 self.backend_policy = None
+
+            if self.route or force:
+                self._delete_gamma_route(self.route_name)
+                self.route = None
+
+            if self.frontend_service or force:
+                self._delete_service(self.frontend_service_name)
+                self.frontend_service = None
+
+            if (self.service and not self.reuse_service) or force:
+                self._delete_service(self.service_name)
+                self.service = None
+
+            if self.deployment or force:
+                self._delete_deployment(self.deployment_name)
+                self.deployment = None
 
             if self.enable_workload_identity and (
                 self.service_account or force


### PR DESCRIPTION
We want to delete resources in the reversed creation order. 

This PR speeds up the cleanup of session affinity tests fixing the order in which `GCPBackendPolicy` and `GCPSessionAffinityFilter`/`GCPSessionAffinityPolicy` are deleted. Before this PR, this resources were deleted after `Service`, `Route`, `Deployment` they were pointing to. This resulted in extended waits of namespace (tree root) deletion.

By deleting `GCPBackendPolicy`, `GCPSessionAffinityFilter`/`GCPSessionAffinityPolicy` first, the order is fixed, and the namespace deletion op is sped up significantly.

Before - 2.5 min:
```
21:46:52 k8s_base_runner.py:913] Deleting namespace sergiitk-server-20240307-0542-6rse5
21:49:22 k8s_base_runner.py:930] Namespace sergiitk-server-20240307-0542-6rse5 deleted
```

After - 1 min:
```
22:02:24 k8s_base_runner.py:913] Deleting namespace sergiitk-server-20240307-0557-x1s5d
22:03:24 k8s_base_runner.py:930] Namespace sergiitk-server-20240307-0557-x1s5d deleted
```