### PR TITLE
Wait for xds control plane, server: preserve trace of the last error

### DIFF
--- a/framework/test_app/client_app.py
+++ b/framework/test_app/client_app.py
@@ -154,12 +154,14 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
                 rpc_deadline=rpc_deadline,
             )
         except retryers.RetryError as retry_err:
-            if isinstance(retry_err.exception(), self.ChannelNotFound):
-                retry_err.add_note(
-                    framework.errors.FrameworkError.note_blanket_error(
-                        "The client couldn't connect to the server."
+            if cause := retry_err.exception():
+                if isinstance(cause, self.ChannelNotFound):
+                    retry_err.add_note(
+                        framework.errors.FrameworkError.note_blanket_error(
+                            "The client couldn't connect to the server."
+                        )
                     )
-                )
+                raise retry_err from cause
             raise
 
     def wait_for_active_xds_channel(
@@ -181,12 +183,15 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
                 rpc_deadline=rpc_deadline,
             )
         except retryers.RetryError as retry_err:
-            if isinstance(retry_err.exception(), self.ChannelNotFound):
-                retry_err.add_note(
-                    framework.errors.FrameworkError.note_blanket_error(
-                        "The client couldn't connect to the xDS control plane."
+            if cause := retry_err.exception():
+                if isinstance(cause, self.ChannelNotFound):
+                    retry_err.add_note(
+                        framework.errors.FrameworkError.note_blanket_error(
+                            "The client couldn't connect to the"
+                            " xDS control plane."
+                        )
                     )
-                )
+                raise retry_err from cause
             raise
 
     def get_active_server_channel_socket(self) -> _ChannelzSocket:


### PR DESCRIPTION
On retry errors timeout waiting for the control plane / server channel READY channel, we're not printing the traceback of the final retry attempt error; just the str(error) itself. It makes it hard to identify what exact operation failed. 

This PR changes this. New trace (before we'd see just the second part):

```
I0312 20:48:45.975962 140704686801152 client_app.py:293] [psm-grpc-client-6f998fd5d8-zjm48] ADS: Waiting for active calls to xDS control plane to trafficdirector.googleapis.com:443
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/tenacity/__init__.py", line 426, in __call__
    result = fn(*args, **kwargs)
  File "/Users/sergiitk/Development/psm-interop/framework/test_app/client_app.py", line 320, in find_active_xds_channel
    for channel in self.find_channels(xds_server_uri, **rpc_params):
  File "/Users/sergiitk/Development/psm-interop/framework/rpc/grpc_channelz.py", line 130, in <genexpr>
    return (
  File "/Users/sergiitk/Development/psm-interop/framework/rpc/grpc_channelz.py", line 166, in list_channels
    response = self.call_unary_with_deadline(
  File "/Users/sergiitk/Development/psm-interop/framework/rpc/grpc.py", line 72, in call_unary_with_deadline
    return rpc_callable(req, **call_kwargs)
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/grpc/_channel.py", line 1160, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/grpc/_channel.py", line 1003, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.DEADLINE_EXCEEDED
	details = "Deadline Exceeded"
	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2024-03-12T20:48:50.988421-07:00", grpc_status:4, grpc_message:"Deadline Exceeded"}"
>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/bin/run_test_client.py", line 170, in <module>
    app.run(main)
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/absl/app.py", line 312, in run
    _run_main(main, args)
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/absl/app.py", line 258, in _run_main
    sys.exit(main(argv))
  File "/Users/sergiitk/Development/psm-interop/bin/run_test_client.py", line 149, in main
    test_client.wait_for_active_xds_channel(
  File "/Users/sergiitk/Development/psm-interop/framework/test_app/client_app.py", line 195, in wait_for_active_xds_channel
    raise retry_err from cause
  File "/Users/sergiitk/Development/psm-interop/framework/test_app/client_app.py", line 181, in wait_for_active_xds_channel
    return self.wait_for_xds_channel_active(
  File "/Users/sergiitk/Development/psm-interop/framework/test_app/client_app.py", line 298, in wait_for_xds_channel_active
    channel = retryer(
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/tenacity/__init__.py", line 423, in __call__
    do = self.iter(retry_state=retry_state)
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/tenacity/__init__.py", line 369, in iter
    return self.retry_error_callback(retry_state=retry_state)
  File "/Users/sergiitk/Development/psm-interop/framework/helpers/retryers.py", line 147, in error_handler
    raise RetryError(
framework.helpers.retryers.RetryError: Retry error calling framework.test_app.client_app.XdsTestClient.find_active_xds_channel: timeout 0:00:05 (h:mm:ss) exceeded. Last exception: _InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.DEADLINE_EXCEEDED
	details = "Deadline Exceeded"
	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2024-03-12T20:48:50.988421-07:00", grpc_status:4, grpc_message:"Deadline Exceeded"}"
>
```



ref b/329335356