### PR TITLE
Minor changes to test failure error framing

### DIFF
--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -42,12 +42,15 @@ class BaseTestCase(absltest.TestCase):
         if test_errors or test_failures:
             total_errors = len(test_errors) + len(test_failures)
             logging.error(
-                "----- PSM Test Case FAILED: %s%s -----",
-                self.test_name,
-                f" | Errors count: {total_errors}" if total_errors > 1 else "",
+                "----- PSM Test Case FAILED: %s -----", self.test_name
             )
             self._log_test_errors(test_errors, is_unexpected=True)
             self._log_test_errors(test_failures)
+            logging.info(
+                "----- PSM Test Case %s Error Count: %s -----",
+                self.test_name,
+                total_errors,
+            )
         elif test_unexpected_successes:
             logging.error(
                 "----- PSM Test Case UNEXPECTEDLY SUCCEEDED: %s -----\n",
@@ -142,9 +145,9 @@ class BaseTestCase(absltest.TestCase):
         logging.error(
             "(%(fail_type)s) PSM Interop Test Failed: %(test_id)s"
             "\n^^^^^"
-            "\n[%(test_id)s] PSM Failed Test Traceback BEGIN"
+            "\n# [%(test_id)s] PSM Failed Test Traceback BEGIN"
             "\n%(error)s"
-            "[%(test_id)s] PSM Failed Test Traceback END\n",
+            "# [%(test_id)s] PSM Failed Test Traceback END\n",
             {
                 "test_id": test_name,
                 "fail_type": fail_type,


### PR DESCRIPTION
1. Adds `#` before `PSM Failed Test Traceback BEGIN` and `PSM Failed Test Traceback END`. This makes the traceback look nicer when highlighted with python syntax
2. Adds another absl-formatted log statement so that in case only one test run, framed log traceback is not merged together with framework's standard output.

New format examples.

Single trace:
```py
# [FakeParametrizedTest.test_true1] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/venv/lib/python3.9/site-packages/absl/testing/parameterized.py", line 318, in bound_param_test
    return test_method(self, testcase_params)
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 60, in test_true
    self.assertTrue(is_true)
AssertionError: False is not true
# [FakeParametrizedTest.test_true1] PSM Failed Test Traceback END
```


Last test not merged with framework's output:

```
E0313 12:53:58.662293 140704686801152 base_testcase.py:44] ----- PSM Test Case FAILED: FakeSubtestTest.test_even -----
E0313 12:53:58.662406 140704686801152 base_testcase.py:145] (FAILURE) PSM Interop Test Failed: FakeSubtestTest.test_even
^^^^^
# [FakeSubtestTest.test_even] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 80, in test_even
    self.fail(f"Integer {num} is odd")
AssertionError: Integer 1 is odd
# [FakeSubtestTest.test_even] PSM Failed Test Traceback END

I0313 12:53:58.662487 140704686801152 base_testcase.py:49] ----- PSM Test Case FakeSubtestTest.test_even Error Count: 1 -----
======================================================================
FAIL: test_even (__main__.FakeSubtestTest)
FakeSubtestTest.test_even
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/sergiitk/Development/psm-interop/tests/fake_test.py", line 80, in test_even
    self.fail(f"Integer {num} is odd")
AssertionError: Integer 1 is odd

----------------------------------------------------------------------
Ran 1 test in 0.314s
```