### PR TITLE
Fixes new pod log collection when runner.run() called multiple times

### DIFF
--- a/framework/infrastructure/k8s_internal/k8s_log_collector.py
+++ b/framework/infrastructure/k8s_internal/k8s_log_collector.py
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime as dt
 import logging
 import os
 import pathlib
 import threading
-import datetime as dt
 from typing import Any, Callable, Optional, TextIO
 
 from kubernetes import client

--- a/framework/infrastructure/k8s_internal/k8s_log_collector.py
+++ b/framework/infrastructure/k8s_internal/k8s_log_collector.py
@@ -95,7 +95,8 @@ class PodLogCollector(threading.Thread):
             self._watcher = None
         if self._out_stream is not None:
             self._write_with_ts(
-                f"Finished log collection for pod {self.pod_name}",
+                f"[ns/{self.namespace_name}] Finished log collection"
+                f" for pod {self.pod_name}",
                 force_flush=True,
             )
             self._out_stream.close()

--- a/framework/test_app/runners/base_runner.py
+++ b/framework/test_app/runners/base_runner.py
@@ -42,7 +42,7 @@ class BaseRunner(metaclass=ABCMeta):
     def __init__(self):
         if xds_flags.COLLECT_APP_LOGS.value:
             self._logs_subdir = logs.log_dir_mkdir(_LOGS_SUBDIR)
-            self._log_stop_event = threading.Event()
+        self._reset_state()
 
     @property
     @functools.lru_cache(None)
@@ -73,6 +73,11 @@ class BaseRunner(metaclass=ABCMeta):
     @abstractmethod
     def cleanup(self, *, force=False):
         pass
+
+    def _reset_state(self):
+        """Reset the mutable state of the previous run."""
+        if self.should_collect_logs:
+            self._log_stop_event = threading.Event()
 
     @classmethod
     def _logs_explorer_link_from_params(

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -27,7 +27,7 @@ from typing import List, Optional
 import absl.logging
 import mako.lookup
 import mako.template
-from typing_extensions import LiteralString
+from typing_extensions import LiteralString, override
 import yaml
 
 from framework.helpers import retryers
@@ -207,8 +207,9 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
             )
             self.run_history.append(run_history)
 
+    @override
     def _reset_state(self):
-        """Reset the mutable state of the previous run."""
+        super()._reset_state()
         try:
             if self.pod_port_forwarders:
                 logger.warning(


### PR DESCRIPTION
In the subsetting test, only the first client's log was properly collected.  The rest were virtually empty files, with only `Finished log collection for pod psm-grpc-client-..` in them.

This fixes an issue logs not being collected for subsequent calls to client/server runner's `#run()`.
The bug was in the shared log stop threading.Event being reused between different runs. So after the first run sets, log collectors for the following runs see that it's set and immediately finish collecting.
