### PR TITLE
(minor) subsetting_test: better error message for assertLen()

### DIFF
--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -90,7 +90,7 @@ class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                 self.assertLen(
                     parsed.endpoints,
                     _SUBSET_SIZE,
-                    "CSDS endpoints length does not match the subset size:"
+                    "CSDS endpoint length does not match the subset size:"
                     f" expected={_SUBSET_SIZE}, got={len(parsed.endpoints)}",
                 )
                 # Record RPC stats

--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -87,7 +87,12 @@ class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
                     len(parsed.endpoints),
                     parsed.endpoints,
                 )
-                self.assertLen(parsed.endpoints, _SUBSET_SIZE)
+                self.assertLen(
+                    parsed.endpoints,
+                    _SUBSET_SIZE,
+                    "CSDS endpoints length does not match the subset size:"
+                    f" expected={_SUBSET_SIZE}, got={len(parsed.endpoints)}",
+                )
                 # Record RPC stats
                 lb_stats = self.getClientRpcStats(
                     test_client, _NUM_BACKENDS * 25


### PR DESCRIPTION
Current error message is not very suitable for buggrep:

```py
# [SubsettingTest.test_subsetting_basic] PSM Failed Test Traceback BEGIN
Traceback (most recent call last):
  File "/tmp/work/psm-interop/tests/subsetting_test.py", line 90, in test_subsetting_basic
    self.assertLen(parsed.endpoints, _SUBSET_SIZE)
AssertionError: [] has length of 0, expected 4.
# [SubsettingTest.test_subsetting_basic] PSM Failed Test Traceback END
```

Now it will also log `CSDS endpoint length does not match the subset size: expected=4, got=0`

ref b/328630113