### PR TITLE
Kokoro shared lib: Switch CSM tests to the regional cluster

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -53,11 +53,7 @@ activate_gke_cluster() {
       ;;
     GKE_CLUSTER_PSM_CSM)
       GKE_CLUSTER_NAME="psm-interop-csm"
-      GKE_CLUSTER_ZONE="us-east7-c"
-      ;;
-    GKE_CLUSTER_PSM_CSM_REGIONAL)
-      GKE_CLUSTER_NAME="psm-interop-csm"
-      GKE_CLUSTER_REGION="us-central1-a"
+      GKE_CLUSTER_REGION="us-central1"
       ;;
     GKE_CLUSTER_PSM_GAMMA)
       GKE_CLUSTER_NAME="psm-interop-gamma"
@@ -102,7 +98,8 @@ activate_secondary_gke_cluster() {
       exit 1
       ;;
   esac
-  echo "Activated secondary GKE cluster: GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME} GKE_CLUSTER_ZONE=${GKE_CLUSTER_ZONE}"
+  echo -n "Activated secondary GKE cluster: SECONDARY_GKE_CLUSTER_NAME=${SECONDARY_GKE_CLUSTER_NAME}"
+  echo " SECONDARY_GKE_CLUSTER_ZONE=${SECONDARY_GKE_CLUSTER_ZONE}"
 }
 
 #######################################


### PR DESCRIPTION
Move CSM tests to a new regional cluster and support for regional cluster activation.
Note: the new cluster has a same name as the old one (which is allowed since it's a different cluster type): `psm-interop-csm`, region `us-central1`.

Ref b/298501683