### PR TITLE
Cover IPv6 healthcheck ranges in --ensure_firewall

### DIFF
--- a/framework/bootstrap_generator_testcase.py
+++ b/framework/bootstrap_generator_testcase.py
@@ -84,10 +84,12 @@ class BootstrapGeneratorBaseTest(xds_k8s_testcase.XdsKubernetesBaseTestCase):
             cls.resource_prefix, cls.resource_suffix
         )
 
-        # Ensures the firewall exist
+        # Create healthcheck firewall rules if necessary.
         if cls.ensure_firewall:
-            cls.td.create_firewall_rule(
-                allowed_ports=cls.firewall_allowed_ports
+            cls.td.create_firewall_rules(
+                allowed_ports=cls.firewall_allowed_ports,
+                source_range=cls.firewall_source_range,
+                source_range_ipv6=cls.firewall_source_range_ipv6,
             )
 
         # Randomize xds port, when it's set to 0

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -724,6 +724,8 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
             allowed_ports,
         )
 
+        # A separate fw rule is needed because mixing IPv4 and IPv6 in the same
+        # rule is not allowed.
         if xds_flags.FIREWALL_SOURCE_RANGE_IPV6.value:
             self.firewall_rule_ipv6 = self._create_firewall_rule(
                 self.make_resource_name(self.FIREWALL_RULE_NAME_IPV6),

--- a/framework/xds_flags.py
+++ b/framework/xds_flags.py
@@ -69,9 +69,10 @@ FIREWALL_SOURCE_RANGE_IPV6 = flags.DEFINE_list(
     default=["2600:2d00:1:b029::/64"],
     help="Update the IPv6 source range of the firewall rule.",
 )
+# Note this needs to cover ports used in GKE probes as well.
 FIREWALL_ALLOWED_PORTS = flags.DEFINE_list(
     "firewall_allowed_ports",
-    default=["8000-8100"],
+    default=["8070-8100"],
     help="Update the allowed ports of the firewall rule.",
 )
 

--- a/framework/xds_flags.py
+++ b/framework/xds_flags.py
@@ -64,9 +64,14 @@ FIREWALL_SOURCE_RANGE = flags.DEFINE_list(
     default=["35.191.0.0/16", "130.211.0.0/22"],
     help="Update the source range of the firewall rule.",
 )
+FIREWALL_SOURCE_RANGE_IPV6 = flags.DEFINE_list(
+    "firewall_source_range_ipv6",
+    default=["2600:2d00:1:b029::/64"],
+    help="Update the IPv6 source range of the firewall rule.",
+)
 FIREWALL_ALLOWED_PORTS = flags.DEFINE_list(
     "firewall_allowed_ports",
-    default=["8080-8100"],
+    default=["8000-8100"],
     help="Update the allowed ports of the firewall rule.",
 )
 

--- a/framework/xds_url_map_test_resources.py
+++ b/framework/xds_url_map_test_resources.py
@@ -269,8 +269,10 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         logging.info("GcpResourceManager: start setup")
         # Firewall
         if self.ensure_firewall:
-            self.td.create_firewall_rule(
-                allowed_ports=self.firewall_allowed_ports
+            self.td.create_firewall_rules(
+                allowed_ports=self.firewall_allowed_ports,
+                source_range=self.firewall_source_range,
+                source_range_ipv6=self.firewall_source_range_ipv6,
             )
         # Health Checks
         self.td.create_health_check()


### PR DESCRIPTION
Flag  `--ensure_firewall` creates on-demand (per-test) firewall rule that GCP healthcheck services to request backend health status over IPv4.
This PR adds support for healtchecks over IPv6 ranges by creating another firewall rule.

https://cloud.google.com/load-balancing/docs/firewall-rules