### PR TITLE
Handle an edge case when k8s ApiException has body with type `bytes`

### DIFF
--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -490,6 +490,8 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         # TODO(sergiitk): [GAMMA] let dynamic/exception parse this instead?
         code: int = err.status
         body = err.body.lower() if err.body else ""
+        if isinstance(body, bytes):
+            body = body.decode("utf-8", "replace")
 
         # 401 Unauthorized: token might be expired, attempt auth refresh.
         if code == 401:


### PR DESCRIPTION
Sometime k8s ApiException may be constructed with `body` of type `bytes`, not `str`. When such ApiException is parsed, framework's `_handle_api_exception` fails with `TypeError: a bytes-like object is required, not 'str'`.

This PR handles this edge-case by casting `body` from `bytes` to `str`.

Trace example:

```py
Traceback (most recent call last):
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/tests/gamma/affinity_policy_test.py", line 36, in test_ping_pong
    test_servers = self.startTestServers(replica_count=REPLICA_COUNT)
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/xds_k8s_testcase.py", line 818, in startTestServers
    test_servers = server_runner.run(
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/gamma_server_runner.py", line 155, in run
    self.route = self._create_gamma_route(
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py", line 469, in _create_gamma_route
    route = self._create_from_template(
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/test_app/runners/k8s/k8s_base_runner.py", line 279, in _create_from_template
    k8s_object = self.k8s_namespace.create_single_resource(
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py", line 476, in create_single_resource
    return self._execute(self._apply_manifest_custom_object, manifest)
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py", line 346, in _execute
    retryer = self._handle_exception(err)
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py", line 383, in _handle_exception
    return self._handle_api_exception(err)
  File "/usr/local/google/home/ginayeh/Workspace/grpc/tools/run_tests/xds_k8s_test_driver/framework/infrastructure/k8s.py", line 441, in _handle_api_exception
    if "connection refused" in body:
TypeError: a bytes-like object is required, not 'str'
```

ref b/298501683