### PR TITLE
outlier_detection_test: don't override go server for rpc-behavior

### DIFF
--- a/tests/custom_lb_test.py
+++ b/tests/custom_lb_test.py
@@ -42,13 +42,19 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         https://github.com/grpc/grpc/blob/master/doc/xds-test-descriptions.md#server
         """
         super().setUpClass()
+        client_lang = cls.lang_spec.client_lang
+
         # gRPC Java implemented server "error-code-" rpc-behavior in v1.47.x.
         # gRPC CPP implemented rpc-behavior in the same version, as custom_lb.
-        if cls.lang_spec.client_lang in _Lang.JAVA | _Lang.CPP:
+        if client_lang in _Lang.JAVA | _Lang.CPP:
+            return
+
+        # gRPC Go implemented server "error-code-" rpc-behavior in v1.59.x,
+        # see https://github.com/grpc/grpc-go/pull/6575.
+        if client_lang == _Lang.GO and cls.lang_spec.version_gte("v1.59.x"):
             return
 
         # gRPC go, python and node fallback to the gRPC Java.
-        # TODO(https://github.com/grpc/grpc-go/issues/6288): use go server.
         # TODO(https://github.com/grpc/grpc/issues/33134): use python server.
         cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value
 

--- a/tests/outlier_detection_test.py
+++ b/tests/outlier_detection_test.py
@@ -53,16 +53,20 @@ class OutlierDetectionTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         https://github.com/grpc/grpc/blob/master/doc/xds-test-descriptions.md#server
         """
         super().setUpClass()
+        client_lang = cls.lang_spec.client_lang
+
         # gRPC Java implemented server "error-code-" rpc-behavior in v1.47.x.
-        if cls.lang_spec.client_lang == _Lang.JAVA:
+        if client_lang == _Lang.JAVA:
             return
 
         # gRPC CPP implemented server "hostname" rpc-behavior in v1.57.x,
         # see https://github.com/grpc/grpc/pull/33446.
-        if (
-            cls.lang_spec.client_lang == _Lang.CPP
-            and cls.lang_spec.version_gte("v1.57.x")
-        ):
+        if client_lang == _Lang.CPP and cls.lang_spec.version_gte("v1.57.x"):
+            return
+
+        # gRPC Go implemented server "hostname" rpc-behavior in v1.59.x,
+        # see https://github.com/grpc/grpc-go/pull/6575.
+        if client_lang == _Lang.GO and cls.lang_spec.version_gte("v1.59.x"):
             return
 
         # gRPC go, python and node fallback to the gRPC Java.


### PR DESCRIPTION
Now that https://github.com/grpc/grpc-go/issues/6288 is closed and released in v1.59.x, we can can use grpc-go xds test server directly (without overriding it with the canonical java). This affects the following tests:

- custom_lb_test
- outlier_detection_test
