### PR TITLE
Update PSM Interop images to Artifact Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ sudo apt-get install python3-venv
 3. Enable gcloud services:
    ```shell
    gcloud services enable \
+     artifactregistry.googleapis.com \
      compute.googleapis.com \
      container.googleapis.com \
      logging.googleapis.com \
@@ -120,18 +121,23 @@ Enable the service account to [access the Traffic Director API](https://cloud.go
 ```shell
 gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
    --member="serviceAccount:${WORKLOAD_SA_EMAIL}" \
-   --role="roles/trafficdirector.client"
+   --role="roles/trafficdirector.client" \
+   --condition="None"
 ```
 
 ##### Allow access to images
 The test framework needs read access to the client and server images and the bootstrap
 generator image. You may have these images in your project but if you want to use these
-from the grpc-testing project you will have to grant the necessary access to these images
-using https://cloud.google.com/container-registry/docs/access-control#grant or a
-gsutil command. For example, to grant access to images stored in `grpc-testing` project GCR, run:
+from the grpc-testing project you will have to grant
+the [necessary access](https://cloud.google.com/artifact-registry/docs/access-control#permissions)
+to these images. To grant access to images stored in `grpc-testing` project GCR,
+run:
 
 ```sh
-gsutil iam ch "serviceAccount:${GCE_SA}:objectViewer" gs://artifacts.grpc-testing.appspot.com/
+gcloud projects add-iam-policy-binding "grpc-testing" \
+    --member="serviceAccount:${GCE_SA}" \
+    --role="roles/artifactregistry.reader" \
+    --condition="None"
 ```
 
 ##### Allow test driver to configure workload identity automatically

--- a/config/common-csm.cfg
+++ b/config/common-csm.cfg
@@ -1,4 +1,4 @@
 # Common config file for PSM CSM tests.
 --resource_prefix=psm-csm
 --noenable_workload_identity
---csm_server_image_canonical=gcr.io/grpc-testing/xds-interop/cpp-server:v1.62.x
+--csm_server_image_canonical=us-docker.pkg.dev/grpc-testing/psm-interop/cpp-server:v1.62.x

--- a/config/common.cfg
+++ b/config/common.cfg
@@ -5,7 +5,7 @@
 # Can be used in tests where language-specific xDS test server does not exist,
 # or missing a feature required for the test.
 # TODO(sergiitk): Update every ~ 6 months; next 2024-01.
---server_image_canonical=gcr.io/grpc-testing/xds-interop/java-server:canonical-v1.56
+--server_image_canonical=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.56
 
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/config/common.cfg
+++ b/config/common.cfg
@@ -1,5 +1,5 @@
 --resource_prefix=psm-interop
---td_bootstrap_image=gcr.io/grpc-testing/td-grpc-bootstrap:2bf1b5ed00f852ffea8d24759c6fa673acc9ef10
+--td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:2bf1b5ed00f852ffea8d24759c6fa673acc9ef10
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,

--- a/config/local-dev.cfg.example
+++ b/config/local-dev.cfg.example
@@ -18,8 +18,8 @@
 ### ------------------------------- App images ---------------------------------
 
 ## Test images, f.e. java v1.57.x.
---server_image=gcr.io/grpc-testing/xds-interop/java-server:v1.57.x
---client_image=gcr.io/grpc-testing/xds-interop/java-client:v1.57.x
+--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:v1.63.x
+--client_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-client:v1.63.x
 
 ### ----------------------------------- App ------------------------------------
 

--- a/config/url-map.cfg
+++ b/config/url-map.cfg
@@ -7,7 +7,7 @@
 # 2. All UrlMap tests today are testing client-side logic.
 #
 # TODO(sergiitk): Use --server_image_canonical instead.
---server_image=gcr.io/grpc-testing/xds-interop/java-server:canonical-v1.56
+--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.56
 
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None

--- a/docker/psm-prestop/README.md
+++ b/docker/psm-prestop/README.md
@@ -6,8 +6,8 @@ From the repo root:
 
 ```sh
 PRESTOP_INIT_VERSION="v0.0.4"
-docker build -f ./docker/psm-prestop/prestop.Dockerfile -t "gcr.io/grpc-testing/xds-interop/prestop-hook:${PRESTOP_INIT_VERSION:-dev}" .
-docker push "gcr.io/grpc-testing/xds-interop/prestop-hook:${PRESTOP_INIT_VERSION:-dev}"
+docker build -f ./docker/psm-prestop/prestop.Dockerfile -t "us-docker.pkg.dev/grpc-testing/psm-interop/prestop-hook:${PRESTOP_INIT_VERSION:-dev}" .
+docker push "us-docker.pkg.dev/grpc-testing/psm-interop/prestop-hook:${PRESTOP_INIT_VERSION:-dev}"
 ```
 
 Build in publishing steps will be automated.\

--- a/kubernetes-manifests/prestop-hook.yaml
+++ b/kubernetes-manifests/prestop-hook.yaml
@@ -22,7 +22,7 @@ PRESTOP_MOUNT_PATH = '/tmp/prestop-hook'
       ## initContainers:
         - name: prestop-hook-init
           ## TODO(sergiitk): parametrize prestop hook image
-          image: gcr.io/grpc-testing/xds-interop/prestop-hook:v0.0.6
+          image: us-docker.pkg.dev/grpc-testing/psm-interop/prestop-hook:v0.0.6
           imagePullPolicy: Always
           args: ["${PRESTOP_MOUNT_PATH}"]
           resources:

--- a/tests/bootstrap_generator_test.py
+++ b/tests/bootstrap_generator_test.py
@@ -38,7 +38,9 @@ _timedelta = datetime.timedelta
 
 # Constants
 GCR_PROD: Final[str] = "gcr.io/trafficdirector-prod/td-grpc-bootstrap"
-GCR_TESTING: Final[str] = "gcr.io/grpc-testing/td-grpc-bootstrap"
+GCR_TESTING: Final[
+    str
+] = "us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap"
 
 
 # Returns a list of bootstrap generator versions to be tested along with their
@@ -64,7 +66,7 @@ def bootstrap_version_testcases() -> Sequence[dict[str, str]]:
         #
         # TODO: Figure out how to pass flags to the bootstrap generator via the
         # client and server runners, and uncomment this version.
-        # ('v0.10.0', 'gcr.io/grpc-testing/td-grpc-bootstrap:66de7ea0e170351c9fae17232b81adbfb3e80ec3'),
+        # dict(version="v0.10.0", image=f"{GCR_PROD}:0.10.0"),
     )
 
 


### PR DESCRIPTION
Migrates PSM Interop and TD gRPC bootstrap preprod images from Container Registry (gcr.io) to Artifact Registry (pkg.dev). Container Registry deprecation notice: https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation.

Related:
- Ref b/289578176
- Bootstrap Generator: GoogleCloudPlatform/traffic-director-grpc-bootstrap#58
- Java: https://github.com/grpc/grpc-java/pull/11079
- Go: https://github.com/grpc/grpc-go/pull/7102
- CPP: https://github.com/grpc/grpc/pull/36273
- Node: https://github.com/grpc/grpc-node/pull/2712