### PR TITLE
Move all common buildscript functionality to psm_interop_kokoro_lib.sh

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -534,6 +534,24 @@ psm::tools::run_verbose() {
   return ${exit_code}
 }
 
+#######################################
+# Run command end report its exit code. Doesn't exit on non-zero exit code.
+# Globals:
+#   None
+# Arguments:
+#   Command to execute
+# Outputs:
+#   Writes the output of given command to stdout, stderr
+#######################################
+psm::tools::run_ignore_exit_code() {
+  local exit_code=0
+  "$@" || exit_code=$?
+
+  if (( exit_code == 0 )); then
+    psm::tools::log "Cmd failed with exit code ${exit_code}: $*"
+  fi
+}
+
 psm::tools::log() {
   echo -en "+ $(date "+[%H:%M:%S %Z]")\011 "
   echo "$@"
@@ -624,6 +642,10 @@ activate_secondary_gke_cluster() {
 
 #######################################
 # Run command end report its exit code. Doesn't exit on non-zero exit code.
+#
+# Deprecated. Use psm::tools::run_ignore_exit_code
+# TODO(sergiitk): delete this method when no longer used in per-language buildscripts.
+#
 # Globals:
 #   None
 # Arguments:

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -237,6 +237,8 @@ psm::run::test_suite() {
   local failed_tests=0
   for test_name in "${TESTS[@]}"; do
     psm::run::test "${test_suite}" "${test_name}" || (( ++failed_tests ))
+    psm::tools::log "Finished ${test_suite} suite test: ${test_name}"
+    echo
   done
   psm::tools::log "Failed test suites: ${failed_tests}"
 }
@@ -302,7 +304,7 @@ psm::setup::generic_test_suite() {
 
   "psm::${test_suite}::get_tests"
   psm::tools::log "Tests in ${test_suite} test suite:"
-  printf -- "- %s\n" "${TESTS[@]}"
+  printf -- "  - %s\n" "${TESTS[@]}"
   echo
 }
 
@@ -382,13 +384,13 @@ psm::setup::test_driver() {
 psm::build::docker_images_if_needed() {
   # Check if images already exist
   client_tags="$(gcloud_gcr_list_image_tags "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}")"
-  printf "Client image: %s:%s\n" "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}"
-  psm::tools::log "${client_tags:-Client image not found}"
+  psm::tools::log "Client image: ${CLIENT_IMAGE_NAME}:${GIT_COMMIT}"
+  echo "${client_tags:-Client image not found}"
 
   if [[ -z "${SERVER_IMAGE_USE_CANONICAL}" ]]; then
     server_tags="$(gcloud_gcr_list_image_tags "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}")"
-    printf "Server image: %s:%s\n" "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}"
-    psm::tools::log "${server_tags:-Server image not found}"
+    psm::tools::log "Server image: ${SERVER_IMAGE_NAME}:${GIT_COMMIT}"
+    echo "${server_tags:-Server image not found}"
   else
     server_tags="ignored-use-canonical"
   fi
@@ -429,7 +431,7 @@ psm::tools::log() {
 
 psm::tools::print_test_flags() {
   local test_name="${1:?missing the test name argument}"
-  psm::tools::log "${test_name} PSM test flags:"
+  psm::tools::log "Test driver flags for ${test_name}:"
   printf -- "%s\n" "${PSM_TEST_FLAGS[@]}"
   echo
 }

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -665,7 +665,7 @@ test_driver_pip_install() {
     source "${venv_dir}/bin/activate"
   fi
 
-  psm::tools::log "Installed Python packages with pip, see install-pip.log"
+  psm::tools::log "Installing Python packages with pip, see install-pip.log"
   psm::driver::pip_install &>> "${BUILD_LOGS_ROOT}/install-pip.log"
 }
 
@@ -887,6 +887,7 @@ kokoro_setup_test_driver() {
   kokoro_install_dependencies &> "${BUILD_LOGS_ROOT}/install-apt.log"
 
   # Get kubectl cluster credentials.
+  psm::tools::log "Fetching GKE cluster credentials"
   gcloud_get_cluster_credentials
 
   # Install the driver.

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -14,6 +14,9 @@
 # limitations under the License.
 set -eo pipefail
 
+# Prepend verbose mode commands (xtrace) with the date.
+PS4='+ $(date "+[%H:%M:%S %Z]")\011 '
+
 # Constants
 readonly PYTHON_VERSION="${PYTHON_VERSION:-3.10}"
 # Test driver
@@ -962,10 +965,7 @@ kokoro_get_testing_version() {
 kokoro_setup_test_driver() {
   # Unset noisy verbose mode often set in the parent scripts.
   set +x
-
-  # Prepend verbose mode commands (xtrace) with the date.
-  PS4='+ $(date "+[%H:%M:%S %Z]")\011 '
-
+  
   psm::tools::log "Starting Kokoro provisioning"
 
   local src_repository_name="${1:?Usage kokoro_setup_test_driver GITHUB_REPOSITORY_NAME}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -71,10 +71,8 @@ psm::lb::get_tests() {
       )
   fi
 
-  # Prevent buildscripts from appending to the list of tests.
-  declare -r TESTS
   echo "LB test suite:"
-  printf "%s\n" "${TESTS[@]}"
+  printf -- "- %s\n" "${TESTS[@]}"
 }
 
 psm::lb::run() {

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -525,7 +525,7 @@ psm::tools::run_verbose() {
   if (( exit_code == 0 )); then
     psm::tools::log "Cmd finished: ${1}"
   else
-    psm::tools::log "Cmd exit code ${exit_code}: '$*'"
+    psm::tools::log "Cmd failed with exit code ${exit_code}: $*"
   fi
 
   return ${exit_code}

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -37,13 +37,11 @@ readonly GKE_CLUSTER_PSM_BASIC="psm-basic"
 # --- LB TESTS ---
 
 #######################################
-# Returns the list of tests in LB test suite.
+# Prepares the list of tests in PSM LB test suite.
 # Globals:
-#   TESTING_VERSION: Populated with the version branch under test,
-#                    f.e. master, dev, v1.42.x.
-#   TESTS: An array of tests LB tests.
+#   TESTING_VERSION: The version branch under test, f.e. master, dev, v1.42.x.
+#   TESTS: Populated with tests in PSM LB test suite.
 # Outputs:
-#   Sets variable TESTS.
 #   Prints TESTS to stdout.
 #######################################
 psm::lb::get_tests() {
@@ -82,11 +80,10 @@ psm::lb::run() {
 # --- Security TESTS ---
 
 #######################################
-# Returns the list of tests in PSM Security test suite.
+# Prepares the list of tests in PSM Security test suite.
 # Globals:
-#   TESTS: An array of tests LB tests.
+#   TESTS: Populated with tests in PSM Security test suite.
 # Outputs:
-#   Sets variable TESTS.
 #   Prints TESTS to stdout.
 #######################################
 psm::security::get_tests() {
@@ -111,11 +108,10 @@ psm::security::run() {
 # --- URL Map TESTS ---
 
 #######################################
-# Returns the list of tests in URL Map test suite.
+# Prepares the list of tests in URL Map test suite.
 # Globals:
-#   TESTS: An array of tests LB tests.
+#   TESTS: Populated with tests in URL Map test suite.
 # Outputs:
-#   Sets variable TESTS.
 #   Prints TESTS to stdout.
 #######################################
 psm::url_map::get_tests() {

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -194,16 +194,17 @@ psm::run_tests() {
 }
 
 psm::setup_test_driver() {
+  local build_docker_script="${BUILD_SCRIPT_DIR}/psm-interop-build-${GRPC_LANGUAGE}.sh"
+  echo "Looking for docker image build script ${build_docker_script}"
+  if [[ -f "${build_docker_script}" ]]; then
+    echo "Sourcing docker image build script: ${build_docker_script}"
+    source "${build_docker_script}"
+  fi
+  
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
     kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"
   else
     local_setup_test_driver "${BUILD_SCRIPT_DIR}"
-  fi
-
-  local build_docker_script="${BUILD_SCRIPT_DIR}/psm-interop-build-${GRPC_LANGUAGE}.sh"
-  if [[ -f "${build_docker_script}" ]]; then
-    echo "Sourcing ${build_docker_script}"
-    source "${build_docker_script}"
   fi
 }
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -94,7 +94,7 @@ psm::lb::get_tests() {
 #   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
 #######################################
 psm::lb::run_test() {
-  local test_name="${1:?missing the test name argument}"
+  local test_name="${1:?${FUNCNAME[0]} missing the test name argument}"
   psm::tools::print_test_flags "${test_name}"
   psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
 }
@@ -135,14 +135,14 @@ psm::security::get_tests() {
 #   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
 #######################################
 psm::security::run_test() {
-  local test_name="${1:?missing the test name argument}"
+  local test_name="${1:?${FUNCNAME[0]} missing the test name argument}"
 
   # Only java supports extra checks for certificate matches (via channelz socket info).
   if [[ "${GRPC_LANGUAGE}" != "java"  ]]; then
     PSM_TEST_FLAGS+=("--nocheck_local_certs")
   fi
 
-  psm::tools::print_test_flags
+  psm::tools::print_test_flags "${test_name}"
   psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
 }
 
@@ -177,11 +177,11 @@ psm::url_map::get_tests() {
 #   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
 #######################################
 psm::url_map::run_test() {
-  local test_name="${1:?missing the test name argument}"
+  local test_name="${1:?${FUNCNAME[0]} missing the test name argument}"
   PSM_TEST_FLAGS+=(
     "--flagfile=config/url-map.cfg"
   )
-  psm::tools::print_test_flags
+  psm::tools::print_test_flags "${test_name}"
   psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
 }
 
@@ -223,11 +223,11 @@ psm::csm::get_tests() {
 #   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
 #######################################
 psm::csm::run_test() {
-  local test_name="${1:?missing the test name argument}"
+  local test_name="${1:?${FUNCNAME[0]} missing the test name argument}"
   PSM_TEST_FLAGS+=(
     "--flagfile=config/common-csm.cfg"
   )
-  psm::tools::print_test_flags
+  psm::tools::print_test_flags "${test_name}"
   psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
 }
 
@@ -255,7 +255,7 @@ psm::csm::run_test() {
 #   Writes the output of test execution to stdout, stderr
 #######################################
 psm::run() {
-  local test_suite="${1:?missing the test suite argument}"
+  local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
   psm::setup::docker_image_names "${GRPC_LANGUAGE}" "${test_suite}"
 
   case "${test_suite}" in
@@ -281,7 +281,7 @@ psm::run() {
 #   TBD
 #######################################
 psm::run::test_suite() {
-  local test_suite="${1:?missing the test suite argument}"
+  local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
   cd "${TEST_DRIVER_FULL_DIR}"
   local failed_tests=0
   for test_name in "${TESTS[@]}"; do
@@ -311,8 +311,8 @@ psm::run::test_suite() {
 #######################################
 psm::run::test() {
   # Test driver usage: https://github.com/grpc/psm-interop#basic-usage
-  local test_suite="${1:?missing the test suite argument}"
-  local test_name="${2:?missing the test name argument}"
+  local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
+  local test_name="${2:?${FUNCNAME[0]} missing the test name argument}"
   local out_dir="${TEST_XML_OUTPUT_DIR}/${test_name}"
   local test_log="${out_dir}/sponge_log.log"
   mkdir -p "${out_dir}"
@@ -346,7 +346,7 @@ psm::run::test() {
 # --- Common test setup logic -----------
 
 psm::setup::generic_test_suite() {
-  local test_suite="${1:?missing the test suite argument}"
+  local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
   "psm::${test_suite}::setup"
   psm::setup::test_driver
   psm::build::docker_images_if_needed
@@ -372,8 +372,8 @@ psm::setup::generic_test_suite() {
 #   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
 #######################################
 psm::setup::docker_image_names() {
-  local language="${1:?missing the language argument}"
-  local test_suite="${2:?missing the test suite argument}"
+  local language="${1:?${FUNCNAME[0]} missing the language argument}"
+  local test_suite="${2:?${FUNCNAME[0]} missing the test suite argument}"
 
   case "${language}" in
     java | cpp | python)
@@ -472,7 +472,7 @@ psm::build::docker_images_if_needed() {
 #   Writes the output of docker image build stdout, stderr
 #######################################
 psm::build::docker_images_generic() {
-  local client_dockerfile="${1:?missing the client dockerfile argument}"
+  local client_dockerfile="${1:?${FUNCNAME[0]} missing the client dockerfile argument}"
   local server_dockerfile="${2:-}"
   pushd "${SRC_DIR}"
 
@@ -521,7 +521,7 @@ psm::tools::log() {
 }
 
 psm::tools::print_test_flags() {
-  local test_name="${1:?missing the test name argument}"
+  local test_name="${1:?${FUNCNAME[0]} missing the test name argument}"
   psm::tools::log "Test driver flags for ${test_name}:"
   printf -- "%s\n" "${PSM_TEST_FLAGS[@]}"
   echo

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -355,13 +355,17 @@ psm::setup::test_driver() {
 #######################################
 psm::build::docker_images_if_needed() {
   # Check if images already exist
-  server_tags="$(gcloud_gcr_list_image_tags "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}")"
-  printf "Server image: %s:%s\n" "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}"
-  echo "${server_tags:-Server image not found}"
-
   client_tags="$(gcloud_gcr_list_image_tags "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}")"
   printf "Client image: %s:%s\n" "${CLIENT_IMAGE_NAME}" "${GIT_COMMIT}"
   echo "${client_tags:-Client image not found}"
+
+  if [[ -n "${SERVER_IMAGE_NAME}" ]]; then
+    server_tags="$(gcloud_gcr_list_image_tags "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}")"
+    printf "Server image: %s:%s\n" "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}"
+    echo "${server_tags:-Server image not found}"
+  else
+    server_tags="ignored"
+  fi
 
   # Build if any of the images are missing, or FORCE_IMAGE_BUILD=1
   if [[ "${FORCE_IMAGE_BUILD_PSM}" == "1" || -z "${server_tags}" || -z "${client_tags}" ]]; then

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -30,7 +30,10 @@ readonly FORCE_TESTING_VERSION="${FORCE_TESTING_VERSION:-}"
 readonly FORCE_IMAGE_BUILD_PSM="${FORCE_IMAGE_BUILD:-0}"
 
 # Docker
-readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+# TODO(sergiitk): if can be removed when DOCKER_REGISTRY removed from buildscripts.
+if [[ -z "${DOCKER_REGISTRY}" ]] ; then
+  readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+fi
 
 # GKE cluster identifiers.
 readonly GKE_CLUSTER_PSM_LB="psm-lb"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -194,18 +194,17 @@ psm::run_tests() {
 }
 
 psm::setup_test_driver() {
-  local build_docker_script="${BUILD_SCRIPT_DIR}/psm-interop-build-${GRPC_LANGUAGE}.sh"
-  if [[ -f "${build_docker_script}" ]]; then
-    echo "Sourcing ${build_docker_script}"
-    source "${build_docker_script}"
-  fi
-
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
     kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"
   else
     local_setup_test_driver "${BUILD_SCRIPT_DIR}"
   fi
 
+  local build_docker_script="${BUILD_SCRIPT_DIR}/psm-interop-build-${GRPC_LANGUAGE}.sh"
+  if [[ -f "${build_docker_script}" ]]; then
+    echo "Sourcing ${build_docker_script}"
+    source "${build_docker_script}"
+  fi
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -376,9 +376,9 @@ psm::setup::docker_image_names() {
   local test_suite="${2:?missing the test suite argument}"
 
   case "${language}" in
-    java)
-      CLIENT_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
-      SERVER_IMAGE_NAME="us-docker.pkg.dev/grpc-testing/psm-interop/${GRPC_LANGUAGE}-server"
+    java | cpp | python)
+      CLIENT_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
+      SERVER_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-server"
       ;;
     *)
       psm::tools::log "Unknown Language: ${1}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -67,7 +67,7 @@ psm::get_lb_tests() {
       )
   fi
 
-  echo "Running LB suite tests:"
+  echo "LB test suite:"
   printf "%s\n" "${TESTS[@]}"
 }
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -194,19 +194,17 @@ psm::run_tests() {
 }
 
 psm::setup_test_driver() {
-  local script_dir
-  script_dir="$(dirname "$0")"
   set -x
-  echo "Sourcing ${script_dir}/psm-interop-build.sh"
-  if [[ -f "${script_dir}/psm-interop-build.sh" ]]; then
-    source "${script_dir}/psm-interop-build.sh"
+  echo "Sourcing ${BUILD_SCRIPT_DIR}/psm-interop-build.sh"
+  if [[ -f "${BUILD_SCRIPT_DIR}/psm-interop-build.sh" ]]; then
+    source "${BUILD_SCRIPT_DIR}/psm-interop-build.sh"
   fi
   set +x
 
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
     kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"
   else
-    local_setup_test_driver "${script_dir}"
+    local_setup_test_driver "${BUILD_SCRIPT_DIR}"
   fi
 
 }

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -376,7 +376,7 @@ psm::setup::docker_image_names() {
   local test_suite="${2:?${FUNCNAME[0]} missing the test suite argument}"
 
   case "${language}" in
-    java | cpp | python)
+    java | cpp | python | go)
       CLIENT_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
       SERVER_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-server"
       ;;

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -26,6 +26,9 @@ readonly FORCE_TESTING_VERSION="${FORCE_TESTING_VERSION:-}"
 # TODO(sergiitk): can be defined as readonly FORCE_IMAGE_BUILD when removed from buildscripts.
 readonly FORCE_IMAGE_BUILD_PSM="${FORCE_IMAGE_BUILD:-0}"
 
+# Docker
+readonly DOCKER_REGISTRY="us-docker.pkg.dev"
+
 # GKE cluster identifiers.
 readonly GKE_CLUSTER_PSM_LB="psm-lb"
 readonly GKE_CLUSTER_PSM_SECURITY="psm-security"
@@ -399,6 +402,7 @@ psm::build::docker_images_if_needed() {
   if [[ "${FORCE_IMAGE_BUILD_PSM}" == "1" || -z "${server_tags}" || -z "${client_tags}" ]]; then
     {
       psm::tools::log "Building xDS interop test app Docker images"
+      gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
       psm::lang::build_docker_images
       psm::tools::log "Finished xDS interop test app Docker images"
     } | tee -a "${BUILD_LOGS_ROOT}/build-docker.log"
@@ -959,6 +963,6 @@ tag_and_push_docker_image() {
   local from_tag="$2"
   local to_tag="$3"
 
-  docker tag "${image_name}:${from_tag}" "${image_name}:${to_tag}"
-  docker push "${image_name}:${to_tag}"
+  psm::tools::run_verbose docker tag "${image_name}:${from_tag}" "${image_name}:${to_tag}"
+  psm::tools::run_verbose push "${image_name}:${to_tag}"
 }

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -50,9 +50,7 @@ psm::lb::setup() {
 # Prepares the list of tests in PSM LB test suite.
 # Globals:
 #   TESTING_VERSION: The version branch under test, f.e. master, dev, v1.42.x.
-#   TESTS: Populated with tests in PSM LB test suite.
-# Outputs:
-#   Prints TESTS to stdout.
+#   TESTS: Populated with tests in the test suite.
 #######################################
 psm::lb::get_tests() {
   # TODO(sergiitk): remove after debugging
@@ -86,7 +84,7 @@ psm::lb::get_tests() {
 }
 
 #######################################
-# Executes LB test case
+# Executes LB test case.
 # Globals:
 #   TBD
 # Arguments:
@@ -116,8 +114,6 @@ psm::security::setup() {
 # Prepares the list of tests in PSM Security test suite.
 # Globals:
 #   TESTS: Populated with tests in PSM Security test suite.
-# Outputs:
-#   Prints TESTS to stdout.
 #######################################
 psm::security::get_tests() {
   # TODO(sergiitk): load from env var?
@@ -164,16 +160,14 @@ psm::url_map::setup() {
 #######################################
 # Prepares the list of tests in URL Map test suite.
 # Globals:
-#   TESTS: Populated with tests in URL Map test suite.
-# Outputs:
-#   None
+#   TESTS: Populated with tests in the test suite.
 #######################################
 psm::url_map::get_tests() {
   TESTS=("url_map")
 }
 
 #######################################
-# Executes Security test case
+# Executes URL Map test case
 # Globals:
 #   TBD
 # Arguments:
@@ -186,6 +180,52 @@ psm::url_map::run_test() {
   local test_name="${1:?missing the test name argument}"
   PSM_TEST_FLAGS+=(
     "--flagfile=config/url-map.cfg"
+  )
+  psm::tools::print_test_flags
+  psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
+}
+
+# --- CSM TESTS ------------------
+
+#######################################
+# CSM Test Suite setup.
+# Outputs:
+#   Prints activated cluster names.
+#######################################
+psm::csm::setup() {
+  activate_gke_cluster GKE_CLUSTER_PSM_CSM
+}
+
+#######################################
+# Prepares the list of tests in CSM test suite.
+# Globals:
+#   TESTS: Populated with tests in the test suite.
+#######################################
+psm::csm::get_tests() {
+  # TODO(sergiitk): load from env var?
+  TESTS=(
+    "gamma.gamma_baseline_test"
+    "gamma.affinity_test"
+    "gamma.affinity_session_drain_test"
+    "gamma.csm_observability_test"
+    "app_net_ssa_test"
+  )
+}
+
+#######################################
+# Executes CSM test case
+# Globals:
+#   TBD
+# Arguments:
+#   Test case name
+# Outputs:
+#   Writes the output of test execution to stdout, stderr
+#   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
+#######################################
+psm::csm::run_test() {
+  local test_name="${1:?missing the test name argument}"
+  PSM_TEST_FLAGS+=(
+    "--flagfile=config/common-csm.cfg"
   )
   psm::tools::print_test_flags
   psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
@@ -219,7 +259,7 @@ psm::run() {
   psm::setup::docker_image_names "${GRPC_LANGUAGE}" "${test_suite}"
 
   case "${test_suite}" in
-    lb | security | url_map)
+    lb | security | url_map | csm)
       psm::setup::generic_test_suite "${test_suite}"
       ;;
     *)

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -30,6 +30,47 @@ readonly GKE_CLUSTER_PSM_LB="psm-lb"
 readonly GKE_CLUSTER_PSM_SECURITY="psm-security"
 readonly GKE_CLUSTER_PSM_BASIC="psm-basic"
 
+# TODO(sergiitk): all methods should be using "psm::" package name,
+#   see https://google.github.io/styleguide/shellguide.html#function-names
+
+#######################################
+# Returns the list of tests in LN test suite.
+# Globals:
+#   TESTING_VERSION: Populated with the version branch under test,
+#                    f.e. master, dev, v1.42.x.
+#   TESTS: An array of tests LB tests.
+# Outputs:
+#   Sets variable TESTS.
+#   Prints TESTS to stdout.
+#######################################
+psm::get_lb_tests() {
+  # readarray -t myArray < "$1"
+
+  declare -a TESTS
+  TESTS=(
+    "affinity_test"
+    "api_listener_test"
+    "app_net_test"
+    "change_backend_service_test"
+    "custom_lb_test"
+    "failover_test"
+    "outlier_detection_test"
+    "remove_neg_test"
+    "round_robin_test"
+  )
+
+  # master-only tests
+  if [[ "${TESTING_VERSION}" =~ "master" ]]; then
+      TESTS+=(
+        "bootstrap_generator_test"
+        "subsetting_test"
+      )
+  fi
+
+  echo "Running LB suite tests:"
+  printf "%s\n" "${TESTS[@]}"
+}
+
 #######################################
 # Determines the cluster name and zone based on the given cluster identifier.
 # Globals:

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -196,6 +196,12 @@ psm::run_tests() {
 psm::setup_test_driver() {
   local script_dir
   script_dir="$(dirname "$0")"
+  set -x
+  echo "Sourcing ${script_dir}/psm-interop-build.sh"
+  if [[ -f "${script_dir}/psm-interop-build.sh" ]]; then
+    source "${script_dir}/psm-interop-build.sh"
+  fi
+  set +x
 
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
     kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"
@@ -203,9 +209,6 @@ psm::setup_test_driver() {
     local_setup_test_driver "${script_dir}"
   fi
 
-  if [[ -f "${script_dir}/psm-interop-build.sh" ]]; then
-    source "${script_dir}/psm-interop-build.sh"
-  fi
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -838,8 +838,11 @@ test_driver_compile_protos() {
     --grpc_python_out="${TEST_DRIVER_FULL_DIR}" \
     "${protos[@]}"
   local protos_out_dir="${TEST_DRIVER_FULL_DIR}/${TEST_DRIVER_PROTOS_PATH}"
-  psm::tools::log "Generated files ${protos_out_dir}:"
-  find "${protos_out_dir}" -type f -exec md5sum {} \;
+
+  if command -v sha256sum &> /dev/null; then
+    psm::tools::log "Generated files ${protos_out_dir}:"
+    find "${protos_out_dir}" -type f -exec sha256sum {} \;
+  fi
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -262,6 +262,8 @@ psm::csm::run_test() {
 #######################################
 psm::run() {
   local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
+  psm::tools::log "Starting PSM Interop tests: ${test_suite}"
+
   psm::setup::docker_image_names "${GRPC_LANGUAGE}" "${test_suite}"
 
   case "${test_suite}" in
@@ -275,6 +277,7 @@ psm::run() {
   esac
 
   psm::run::test_suite "${test_suite}"
+  psm::tools::log "PSM Interop tests completed: ${test_suite}"
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -95,7 +95,7 @@ psm::lb::run_test() {
   echo "PSM test flags:"
   printf -- "- %s\n" "${PSM_TEST_FLAGS[@]}"
 
-  psm:tools:run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
+  psm::tools::run_verbose python -m "tests.${test_name}" "${PSM_TEST_FLAGS[@]}"
 }
 
 # --- Security TESTS ------------------
@@ -188,7 +188,7 @@ psm::run() {
       ;;
   esac
 
-  psm::run:test_suite "${test_suite}"
+  psm::run::test_suite "${test_suite}"
 }
 
 #######################################
@@ -302,7 +302,7 @@ psm::setup::test_driver() {
 # Outputs:
 #   Writes the output to stdout, stderr
 #######################################
-psm::build_docker_images_if_needed() {
+psm::build::docker_images_if_needed() {
   # Check if images already exist
   server_tags="$(gcloud_gcr_list_image_tags "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}")"
   printf "Server image: %s:%s\n" "${SERVER_IMAGE_NAME}" "${GIT_COMMIT}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -814,7 +814,7 @@ test_driver_compile_protos() {
     "${protos[@]}"
   local protos_out_dir="${TEST_DRIVER_FULL_DIR}/${TEST_DRIVER_PROTOS_PATH}"
   psm::tools::log "Generated files ${protos_out_dir}:"
-  md5sum "${protos_out_dir}/*"
+  find "${protos_out_dir}" -type f -exec md5sum {} \;
 }
 
 #######################################
@@ -965,7 +965,7 @@ kokoro_get_testing_version() {
 kokoro_setup_test_driver() {
   # Unset noisy verbose mode often set in the parent scripts.
   set +x
-  
+
   psm::tools::log "Starting Kokoro provisioning"
 
   local src_repository_name="${1:?Usage kokoro_setup_test_driver GITHUB_REPOSITORY_NAME}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -672,7 +672,7 @@ test_driver_pip_install() {
 psm::driver::pip_install() {
   psm::tools::run_verbose python3 -m pip install -r requirements.lock
   echo
-  psm::tools::run_verbose -m pip list
+  psm::tools::run_verbose python3 -m pip list
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -517,8 +517,15 @@ psm::tools::run_verbose() {
   local exit_code=0
   set -x
   "$@" || exit_code=$?
-  set +x
-  return $exit_code
+  { set +x; } 2>/dev/null
+
+  if (( exit_code == 0 )); then
+    psm::tools::log "Cmd finished: ${1}"
+  else
+    psm::tools::log "Cmd exit code ${exit_code}: '$*'"
+  fi
+
+  return ${exit_code}
 }
 
 psm::tools::log() {

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -806,7 +806,7 @@ test_driver_compile_protos() {
     "${protos[@]}"
   local protos_out_dir="${TEST_DRIVER_FULL_DIR}/${TEST_DRIVER_PROTOS_PATH}"
   psm::tools::log "Generated files ${protos_out_dir}:"
-  du --time --max-depth=1 --all --bytes "${protos_out_dir}"
+  md5sum "${protos_out_dir}/*"
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -331,6 +331,9 @@ psm::run::test() {
   # Some test suites have canonical server image configured in the flagfiles.
   if [[ -z "${SERVER_IMAGE_USE_CANONICAL}" ]]; then
     PSM_TEST_FLAGS+=("--server_image=${SERVER_IMAGE_NAME}:${GIT_COMMIT}")
+  elif [[ "${GRPC_LANGUAGE}" == "node"  ]]; then
+    # TODO(b/261911148): To be replaced with --server_image_use_canonical when implemented.
+    PSM_TEST_FLAGS+=("--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical")
   fi
 
   # So far, only LB test uses secondary GKE cluster.
@@ -379,6 +382,11 @@ psm::setup::docker_image_names() {
     java | cpp | python | go)
       CLIENT_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
       SERVER_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-server"
+      ;;
+    node)
+      CLIENT_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
+      SERVER_IMAGE_NAME=""
+      SERVER_IMAGE_USE_CANONICAL="1"
       ;;
     *)
       psm::tools::log "Unknown Language: ${1}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -235,7 +235,7 @@ psm::build_docker_images_if_needed() {
 
   # Build if any of the images are missing, or FORCE_IMAGE_BUILD=1
   if [[ "${FORCE_IMAGE_BUILD_PSM}" == "1" || -z "${server_tags}" || -z "${client_tags}" ]]; then
-    build_test_app_docker_images
+    psm::lang::build_docker_images
   else
     echo "Skipping ${GRPC_LANGUAGE} test app build"
   fi

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# TODO(sergiitk): move to grpc/grpc when implementing support of other languages
 set -eo pipefail
 
 # Constants
@@ -24,8 +23,7 @@ readonly TEST_DRIVER_BRANCH="${TEST_DRIVER_BRANCH:-main}"
 readonly TEST_DRIVER_PATH=""
 readonly TEST_DRIVER_PROTOS_PATH="protos/grpc/testing"
 readonly FORCE_TESTING_VERSION="${FORCE_TESTING_VERSION:-}"
-# For compatibility with FORCE_IMAGE_BUILD defined in buildscripts.
-# TODO(sergiitk): can be defined as FORCE_IMAGE_BUILD when all buildscripts are updated.
+# TODO(sergiitk): can be defined as readonly FORCE_IMAGE_BUILD when removed from buildscripts.
 readonly FORCE_IMAGE_BUILD_PSM="${FORCE_IMAGE_BUILD:-0}"
 
 # GKE cluster identifiers.
@@ -110,6 +108,30 @@ psm::security::run() {
   psm::run_tests
 }
 
+# --- URL Map TESTS ---
+
+#######################################
+# Returns the list of tests in URL Map test suite.
+# Globals:
+#   TESTS: An array of tests LB tests.
+# Outputs:
+#   Sets variable TESTS.
+#   Prints TESTS to stdout.
+#######################################
+psm::url_map::get_tests() {
+  TESTS=("url_map")
+  echo "URL Map test suite:"
+  printf -- "- %s\n" "${TESTS[@]}"
+}
+
+psm::url_map::run() {
+  activate_gke_cluster GKE_CLUSTER_PSM_BASIC
+  psm::setup_test_driver
+  psm::build_docker_images_if_needed
+  psm::url_map::get_tests
+  psm::run_tests
+}
+
 # --- Common test run ---
 
 #######################################
@@ -140,6 +162,9 @@ psm::run() {
       ;;
     security)
       psm::security::run
+      ;;
+    url_map)
+      psm::url_map::run
       ;;
     *)
       echo "Unknown Test Suite: ${1}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -52,6 +52,14 @@ psm::lb::setup() {
 #   Prints TESTS to stdout.
 #######################################
 psm::lb::get_tests() {
+  # TODO(sergiitk): remove after debugging
+  TESTS=(
+    "app_net_test"
+    "baseline_test"
+  )
+  return
+
+
   # TODO(sergiitk): load from env var?
   TESTS=(
     "affinity_test"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -377,6 +377,7 @@ psm::setup::generic_test_suite() {
 psm::setup::docker_image_names() {
   local language="${1:?${FUNCNAME[0]} missing the language argument}"
   local test_suite="${2:?${FUNCNAME[0]} missing the test suite argument}"
+  SERVER_IMAGE_USE_CANONICAL=""
 
   case "${language}" in
     java | cpp | python | go)
@@ -398,9 +399,6 @@ psm::setup::docker_image_names() {
     url_map)
       # Uses the canonical server image configured in url-map.cfg
       SERVER_IMAGE_USE_CANONICAL="1"
-      ;;
-    *)
-      SERVER_IMAGE_USE_CANONICAL=""
       ;;
   esac
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -194,12 +194,11 @@ psm::run_tests() {
 }
 
 psm::setup_test_driver() {
-  set -x
-  echo "Sourcing ${BUILD_SCRIPT_DIR}/psm-interop-build.sh"
-  if [[ -f "${BUILD_SCRIPT_DIR}/psm-interop-build.sh" ]]; then
-    source "${BUILD_SCRIPT_DIR}/psm-interop-build.sh"
+  local build_docker_script="${BUILD_SCRIPT_DIR}/psm-interop-build-${GRPC_LANGUAGE}.sh"
+  if [[ -f "${build_docker_script}" ]]; then
+    echo "Sourcing ${build_docker_script}"
+    source "${build_docker_script}"
   fi
-  set +x
 
   if [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
     kokoro_setup_test_driver "${GITHUB_REPOSITORY_NAME}"

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -126,13 +126,14 @@ class GcpApiManager:
         return secret.payload.data.decode()
 
     @functools.lru_cache(None)
-    def compute(self, version):
+    def compute(self, version: str):
         api_name = "compute"
+
+        if version.startswith("v1") and self.compute_v1_discovery_file:
+            return self._build_from_file(self.compute_v1_discovery_file)
+
         if version == "v1":
-            if self.compute_v1_discovery_file:
-                return self._build_from_file(self.compute_v1_discovery_file)
-            else:
-                return self._build_from_discovery_v1(api_name, version)
+            return self._build_from_discovery_v1(api_name, version)
         elif version == "v1alpha":
             return self._build_from_discovery_v1(api_name, "alpha")
 

--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -18,6 +18,7 @@ from typing import List
 from absl import flags
 from absl import logging
 from absl.testing import absltest
+from typing_extensions import override
 
 from framework import xds_k8s_testcase
 from framework.helpers import skips
@@ -34,6 +35,12 @@ _NUM_CLIENTS = 3
 
 
 class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
+    @classmethod
+    @override
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.compute_api_version = "v1alpha"
+
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
         # Subsetting is an experimental feature where most work is done on the

--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -18,12 +18,15 @@ from typing import List
 from absl import flags
 from absl import logging
 from absl.testing import absltest
-from typing_extensions import override
 
 from framework import xds_k8s_testcase
 from framework.helpers import skips
 
 flags.adopt_module_key_flags(xds_k8s_testcase)
+# Change the default value of --compute_api_version to v1alpha.
+# Subsetting test requires Compute v1alpha APIs.
+# Can be tested with another API version if the flag is passed to the test.
+flags.set_default(xds_k8s_testcase.xds_flags.COMPUTE_API_VERSION, "v1alpha")
 
 # Type aliases
 _XdsTestServer = xds_k8s_testcase.XdsTestServer
@@ -35,14 +38,6 @@ _NUM_CLIENTS = 3
 
 
 class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
-    @classmethod
-    @override
-    def setUpClass(cls):
-        # TODO(sergiitk): use when absl updated to 1.3.0+, also set
-        #  flags.set_default(xds_flags.COMPUTE_API_VERSION, 'v1alpha')
-        super().setUpClass()
-        cls.compute_api_version = "v1alpha"
-
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
         # Subsetting is an experimental feature where most work is done on the

--- a/tests/subsetting_test.py
+++ b/tests/subsetting_test.py
@@ -38,6 +38,8 @@ class SubsettingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     @classmethod
     @override
     def setUpClass(cls):
+        # TODO(sergiitk): use when absl updated to 1.3.0+, also set
+        #  flags.set_default(xds_flags.COMPUTE_API_VERSION, 'v1alpha')
         super().setUpClass()
         cls.compute_api_version = "v1alpha"
 


### PR DESCRIPTION
Major rework of the shared Kokoro PSM Interop install library.

Nearly all common functionality was moved from per-language/per-branch PSM Interop build scripts to psm_interop_kokoro_lib.sh:
1. The list of tests in the each test suite 
2. Per-test-suite flag customization
3. `run_test` methods
4. `build_docker_images_if_needed` methods
5. Generic `build_test_app_docker_images` methods (simple docker build + docker push + docker tag). grpc-java is one exception, as it doesn't run docker directly, but a cloudbuild flow.

Added new options to control PSM interop test driver execution via environment variables:
```sh
# Overrides the list of test to run. A whitespace-separated string. Example:
# PSM_TESTS="app_net_test baseline_test"
readonly PSM_TESTS="${PSM_TESTS:-}"

# A space-separated string with extra flags to append to the test driver arguments.
# Can be used to execute a run and test a new flag value, f.e.:
# PSM_EXTRA_FLAGS="--noenable_workload_identity --td_bootstrap_image=us-docker.pkg.dev/new-image..."
# In addition, can be used to run a single test in a suite. 
# F.e. to run only test_mtls in security_test:
# PSM_TESTS="security_test" PSM_EXTRA_FLAGS="SecurityTest.test_mtls"
readonly PSM_EXTRA_FLAGS="${PSM_EXTRA_FLAGS:-}"
```

Improved logging:
1. Buildscript test logs are now prepended with the date:
   - when a shell command passed to `psm::tools::run_verbose`
   - `psm::tools::log` is used in place of `echo`
2. Individual install and build steps partially or fully redirected to the dedicated log files:
  - `install-apt.log`
  - `install-pip.log`
  - `build-docker.log`
3. Various other log improvements: printing tests in the suite, printing flags passed to the frameworks, etc

Corresponding per-language buildscript PRs:
1. java - https://github.com/grpc/grpc-java/pull/11121
2. cpp - https://github.com/grpc/grpc/pull/36450
3. go - https://github.com/grpc/grpc-go/pull/7171
4. node - https://github.com/grpc/grpc-node/pull/2729

Notes for the reviewer:
1. The new script is backward-compatible with the old-style buildscripts.
2. Per-language buildscript PRs will be backported to all supported branches, and this should be the very last backport chore we'll ever need.
3. A minor change to the subsetting test was needed to solve [a one-off exception](https://github.com/grpc/grpc/blob/6e981d7460af561230d455c3623774e76e18cbfe/tools/internal_ci/linux/grpc_xds_k8s_lb.sh#L123-L127) from the normal `run_test` flow.

ref b/288578634