### PR TITLE
kokoro: Call 'docker push' correctly while pushing images

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -1138,5 +1138,5 @@ tag_and_push_docker_image() {
   local to_tag="$3"
 
   psm::tools::run_verbose docker tag "${image_name}:${from_tag}" "${image_name}:${to_tag}"
-  psm::tools::run_verbose push "${image_name}:${to_tag}"
+  psm::tools::run_verbose docker push "${image_name}:${to_tag}"
 }


### PR DESCRIPTION
Presently tests are failing due to the following error:
```
/dev/stdin: line 578: push: command not found
```

The changes were merged in #73 yesterday have a typo:  In file [.kokoro/psm_interop_kokoro_lib.sh, line 1141](https://github.com/grpc/psm-interop/pull/73/files#diff-727d543ec20c63535f31b5e8a83d9ca2762abc4349cc620a105efe9900448cedR1141), `psm::tools::run_verbose push "${image_name}:${to_tag}"` should be `psm::tools::run_verbose docker push "${image_name}:${to_tag}"`.