### PR TITLE
(minor) Kokoro: copy stderr to build-docker.log as well

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -560,7 +560,7 @@ psm::build::docker_images_if_needed() {
       # This method must be defined in the language-specific buildscript.
       psm::lang::build_docker_images
       psm::tools::log "Finished xDS interop test app Docker images"
-    } | tee -a "${BUILD_LOGS_ROOT}/build-docker.log"
+    } |& tee -a "${BUILD_LOGS_ROOT}/build-docker.log"
   else
     psm::tools::log "Skipping ${GRPC_LANGUAGE} test app build"
   fi


### PR DESCRIPTION
Minor: noticed docker build output is missing from `docker-build.log`:

- Example job log: https://btx.cloud.google.com/invocations/59f78821-adde-4484-8b03-f50e9ef2a43c/log
- `docker-build.log` for this job: https://storage.googleapis.com/grpc-testing-kokoro-prod/test_result_public/prod/grpc/node/master/xds_k8s_lb/753/20240503-100346/grpc/node/master/xds_k8s_lb/build-docker.log

Note the lines like `#5 [build 1/9] FROM docker.io/library/node:18-slim@sha256:cbfb3c9830932b7b1c2738abf47c66568fc7b06cf782d803e7ddff52b2fc835d` are missing.