### PR TITLE
[AppNet] Replace NetworkServicesV1Alpha1 with NetworkServicesV1

### DIFF
--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -164,7 +164,7 @@ class GcpApiManager:
                 api_key=self.private_api_key,
                 visibility_labels=["NETWORKSERVICES_ALPHA"],
             )
-        elif version == "v1beta1":
+        elif version in ("v1", "v1beta1"):
             return self._build_from_discovery_v2(api_name, version)
 
         raise NotImplementedError(f"Network Services {version} not supported")

--- a/framework/infrastructure/gcp/network_services.py
+++ b/framework/infrastructure/gcp/network_services.py
@@ -386,21 +386,37 @@ class NetworkServicesV1Beta1(_NetworkServicesBase):
         )
 
 
-class NetworkServicesV1Alpha1(NetworkServicesV1Beta1):
-    """NetworkServices API v1alpha1.
-
-    Note: extending v1beta1 class presumes that v1beta1 is just a v1alpha1 API
-    graduated into a more stable version. This is true in most cases. However,
-    v1alpha1 class can always override and reimplement incompatible methods.
-    """
+class NetworkServicesV1(_NetworkServicesBase):
+    """NetworkServices API v1."""
 
     HTTP_ROUTES = "httpRoutes"
     GRPC_ROUTES = "grpcRoutes"
     MESHES = "meshes"
+    ENDPOINT_POLICIES = "endpointPolicies"
 
     @property
     def api_version(self) -> str:
-        return "v1alpha1"
+        return "v1"
+
+    def create_endpoint_policy(self, name, body: dict) -> GcpResource:
+        return self._create_resource(
+            collection=self._api_locations.endpointPolicies(),
+            body=body,
+            endpointPolicyId=name,
+        )
+
+    def get_endpoint_policy(self, name: str) -> EndpointPolicy:
+        response = self._get_resource(
+            collection=self._api_locations.endpointPolicies(),
+            full_name=self.resource_full_name(name, self.ENDPOINT_POLICIES),
+        )
+        return EndpointPolicy.from_response(name, response)
+
+    def delete_endpoint_policy(self, name: str) -> bool:
+        return self._delete_resource(
+            collection=self._api_locations.endpointPolicies(),
+            full_name=self.resource_full_name(name, self.ENDPOINT_POLICIES),
+        )
 
     def create_mesh(self, name: str, body: dict) -> GcpResource:
         return self._create_resource(

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -40,7 +40,6 @@ ClientTlsPolicy = gcp.network_security.ClientTlsPolicy
 AuthorizationPolicy = gcp.network_security.AuthorizationPolicy
 
 # Network Services
-_NetworkServicesV1Alpha1 = gcp.network_services.NetworkServicesV1Alpha1
 _NetworkServicesV1Beta1 = gcp.network_services.NetworkServicesV1Beta1
 EndpointPolicy = gcp.network_services.EndpointPolicy
 GrpcRoute = gcp.network_services.GrpcRoute
@@ -809,7 +808,7 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
     HTTP_ROUTE_NAME = "http-route"
     MESH_NAME = "mesh"
 
-    netsvc: _NetworkServicesV1Alpha1
+    netsvc: gcp.network_services.NetworkServicesV1
 
     def __init__(
         self,
@@ -831,7 +830,9 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
         )
 
         # API
-        self.netsvc = _NetworkServicesV1Alpha1(gcp_api_manager, project)
+        self.netsvc = gcp.network_services.NetworkServicesV1(
+            gcp_api_manager, project
+        )
 
         # Managed resources
         # TODO(gnossen) PTAL at the pylint error


### PR DESCRIPTION
Replaces  `NetworkServicesV1Alpha1` with `NetworkServicesV1`.

Using `v1alpha1` version of network-services API to manage meshes is no longer needed. Service Routing Mesh features went GA and became available in `v1` network-services API in Q3 2022.

Notes:
1. This change only affects app_net (AKA Service Routing) tests, no other suites use network-services `v1alpha1`.
2. Security test suite uses network-services `v1beta1` (see `NetworkServicesV1Beta1` class). Security suite could probably be switched to `v1` too, but it might make sense to do this separately, and look into replacing  network-security `v1beta1` with `v1` as well.
3. After this change, Private API access key (set in `--private_api_key_secret_name`) will no longer be needed (unless we'll need to use private v1alpha1 APIs again.