### PR TITLE
Introduce `ClientDeploymentArgs`

### DIFF
--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -211,8 +211,6 @@ class GammaServerRunner(KubernetesServerRunner):
             bootstrap_version=bootstrap_version,
             enable_csm_observability=enable_csm_observability,
             generate_mesh_id=generate_mesh_id,
-            csm_workload_name=self.csm_workload_name,
-            csm_canonical_service_name=self.csm_canonical_service_name,
             **self.deployment_args.as_dict(),
         )
 

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -211,6 +211,8 @@ class GammaServerRunner(KubernetesServerRunner):
             bootstrap_version=bootstrap_version,
             enable_csm_observability=enable_csm_observability,
             generate_mesh_id=generate_mesh_id,
+            csm_workload_name=self.csm_workload_name,
+            csm_canonical_service_name=self.csm_canonical_service_name,
             **self.deployment_args.as_dict(),
         )
 


### PR DESCRIPTION
Introduces `ClientDeploymentArgs`, similar to already existing `ServerDeploymentArgs`.

Helps with decluttering `KubernetesClientRunner` class arguments. With this class, no need to create new runner arguments just to pass it to the deployment template.
 