### PR TITLE
Introduce `--verbose_gcp_api` flag to dump GCP requests and responses

### DIFF
--- a/config/local-dev.cfg.example
+++ b/config/local-dev.cfg.example
@@ -39,6 +39,9 @@
 ## Verbosity: -3 (fatal/critical), -2 (error), -1 (warning), 0 (info), 1 (debug)
 # --verbosity=1
 
+# Log all GCP API requests and responses
+# --verbose_gcp_api
+
 ## Uncomment and set different log levels per module. Examples:
 # --logger_levels=__main__:DEBUG,framework:INFO
 # --logger_levels=__main__:INFO,framework:DEBUG,urllib3.connectionpool:ERROR


### PR DESCRIPTION
Create a new flag `--verbose_gcp_api` that enables GCP API verbose logging (requests and responses) by setting the value of global [`googleapiclient.model.dump_request_response`](https://github.com/googleapis/google-api-python-client/blob/5a7b677757badf4324cf5bacfd17534d57500732/googleapiclient/model.py#L39). See [googleapiclient.model.BaseModel._log_request](https://github.com/googleapis/google-api-python-client/blob/5a7b677757badf4324cf5bacfd17534d57500732/googleapiclient/model.py#L108), and other `_log_request` methods in the same file.