### PR TITLE
Add App Net based CSM Observability Test

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -221,6 +221,7 @@ psm::csm::get_tests() {
     "gamma.affinity_session_drain_test"
     "gamma.csm_observability_test"
     "app_net_ssa_test"
+    "app_net_csm_observability_test"
   )
 }
 

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -41,15 +41,10 @@ class GammaServerRunner(KubernetesServerRunner):
     session_affinity_filter: Optional[k8s.GcpSessionAffinityFilter] = None
     session_affinity_policy: Optional[k8s.GcpSessionAffinityPolicy] = None
     backend_policy: Optional[k8s.GcpBackendPolicy] = None
-    pod_monitoring: Optional[k8s.PodMonitoring] = None
-    pod_monitoring_name: Optional[str] = None
 
     route_kind: Final[RouteKind]
     route_name: Final[str]
     frontend_service_name: str
-    enable_csm_observability: bool
-    csm_workload_name: str
-    csm_canonical_service_name: str
 
     SESSION_AFFINITY_FILTER_NAME: Final[str] = "ssa-filter"
     SESSION_AFFINITY_POLICY_NAME: Final[str] = "ssa-policy"
@@ -80,9 +75,6 @@ class GammaServerRunner(KubernetesServerRunner):
         namespace_template: Optional[str] = None,
         debug_use_port_forwarding: bool = False,
         enable_workload_identity: bool = True,
-        enable_csm_observability: bool = False,
-        csm_workload_name: str = "",
-        csm_canonical_service_name: str = "",
         deployment_args: Optional[ServerDeploymentArgs] = None,
     ):
         # pylint: disable=too-many-locals
@@ -111,9 +103,6 @@ class GammaServerRunner(KubernetesServerRunner):
         )
 
         self.frontend_service_name = frontend_service_name
-        self.enable_csm_observability = enable_csm_observability
-        self.csm_workload_name = csm_workload_name
-        self.csm_canonical_service_name = csm_canonical_service_name
         self.route_kind = route_kind
         self.route_name = f"route-{route_kind.value.lower()}-{deployment_name}"
 
@@ -214,16 +203,13 @@ class GammaServerRunner(KubernetesServerRunner):
             maintenance_port=maintenance_port,
             secure_mode=secure_mode,
             bootstrap_version=bootstrap_version,
-            enable_csm_observability=self.enable_csm_observability,
             generate_mesh_id=generate_mesh_id,
-            csm_workload_name=self.csm_workload_name,
-            csm_canonical_service_name=self.csm_canonical_service_name,
             **self.deployment_args.as_dict(),
         )
 
         # Create a PodMonitoring resource if CSM Observability is enabled
         # This is GMP (Google Managed Prometheus)
-        if self.enable_csm_observability:
+        if self.deployment_args.enable_csm_observability:
             self.pod_monitoring_name = f"{self.deployment_id}-gmp"
             self.pod_monitoring = self._create_pod_monitoring(
                 "csm/pod-monitoring.yaml",
@@ -305,7 +291,7 @@ class GammaServerRunner(KubernetesServerRunner):
         secure_mode: bool = False,
         monitoring_port: Optional[int] = None,
     ) -> XdsTestServer:
-        if self.enable_csm_observability:
+        if self.deployment_args.enable_csm_observability:
             if self.debug_use_port_forwarding:
                 pf = self._start_port_forwarding_pod(
                     pod, self.DEFAULT_MONITORING_PORT

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -76,7 +76,7 @@ class KubernetesBaseRunner(base_runner.BaseRunner, metaclass=ABCMeta):
     # Pylint wants abstract classes to override abstract methods.
     # pylint: disable=abstract-method
 
-    DEFAULT_MONITORING_PORT = 9464
+    DEFAULT_POD_MONITORING_PORT = 9464
     TEMPLATE_DIR_NAME = "kubernetes-manifests"
     TEMPLATE_DIR_RELATIVE_PATH = f"../../../../{TEMPLATE_DIR_NAME}"
     ROLE_WORKLOAD_IDENTITY_USER = "roles/iam.workloadIdentityUser"

--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -199,7 +199,7 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
                 namespace_name=self.k8s_namespace.name,
                 deployment_id=self.deployment_id,
                 pod_monitoring_name=self.pod_monitoring_name,
-                pod_monitoring_port=self.DEFAULT_MONITORING_PORT,
+                pod_monitoring_port=self.DEFAULT_POD_MONITORING_PORT,
             )
 
         # We don't support for multiple client replicas at the moment.
@@ -236,13 +236,13 @@ class KubernetesClientRunner(k8s_base_runner.KubernetesBaseRunner):
             rpc_port, rpc_host = pf.local_port, pf.local_address
             if self.deployment_args.enable_csm_observability:
                 pf = self._start_port_forwarding_pod(
-                    pod, self.DEFAULT_MONITORING_PORT
+                    pod, self.DEFAULT_POD_MONITORING_PORT
                 )
                 monitoring_port = pf.local_port
         else:
             rpc_port, rpc_host = self.stats_port, None
             if self.deployment_args.enable_csm_observability:
-                monitoring_port = self.DEFAULT_MONITORING_PORT
+                monitoring_port = self.DEFAULT_POD_MONITORING_PORT
 
         return client_app.XdsTestClient(
             ip=pod.status.pod_ip,

--- a/tests/app_net_csm_observability_test.py
+++ b/tests/app_net_csm_observability_test.py
@@ -173,8 +173,7 @@ class AppNetCsmObservabilityTest(xds_k8s_testcase.AppNetXdsKubernetesTestCase):
 
     @staticmethod
     def is_supported(config: skips.TestConfig) -> bool:
-        if config.client_lang == _Lang.CPP and config.server_lang == _Lang.CPP:
-            # CSM Observability Test is only supported for CPP for now.
+        if config.client_lang == _Lang.CPP:
             return config.version_gte("v1.62.x")
         return False
 

--- a/tests/app_net_csm_observability_test.py
+++ b/tests/app_net_csm_observability_test.py
@@ -248,7 +248,7 @@ class AppNetCsmObservabilityTest(xds_k8s_testcase.AppNetXdsKubernetesTestCase):
                 "Letting test client run for %d seconds to produce metric data",
                 TEST_RUN_SECS,
             )
-            if self.server_runner.should_collect_logs:
+            if self.server_runner.should_collect_logs_prometheus:
                 self._sleep_and_ping_prometheus_endpoint(
                     test_server, test_client
                 )

--- a/tests/app_net_csm_observability_test.py
+++ b/tests/app_net_csm_observability_test.py
@@ -1,4 +1,4 @@
-# Copyright 2023 gRPC authors.
+# Copyright 2024 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -101,7 +101,6 @@ ALL_METRICS = HISTOGRAM_METRICS + COUNTER_METRICS
 GammaServerRunner = gamma_server_runner.GammaServerRunner
 ClientDeploymentArgs = k8s_xds_client_runner.ClientDeploymentArgs
 KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
-ServerDeploymentArgs = k8s_xds_server_runner.ServerDeploymentArgs
 BuildQueryFn = Callable[[str, str], str]
 ANY = unittest.mock.ANY
 
@@ -203,7 +202,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     # each run().
     def initKubernetesServerRunner(self, **kwargs) -> GammaServerRunner:
         return super().initKubernetesServerRunner(
-            deployment_args=ServerDeploymentArgs(
+            deployment_args=gamma_server_runner.ServerDeploymentArgs(
                 enable_csm_observability=True,
                 csm_workload_name=CSM_WORKLOAD_NAME_SERVER,
                 csm_canonical_service_name=CSM_CANONICAL_SERVICE_NAME_SERVER,

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -102,7 +102,6 @@ GammaServerRunner = gamma_server_runner.GammaServerRunner
 ClientDeploymentArgs = k8s_xds_client_runner.ClientDeploymentArgs
 KubernetesClientRunner = k8s_xds_client_runner.KubernetesClientRunner
 ServerDeploymentArgs = k8s_xds_server_runner.ServerDeploymentArgs
-KubernetesServerRunner = k8s_xds_server_runner.KubernetesServerRunner
 BuildQueryFn = Callable[[str, str], str]
 ANY = unittest.mock.ANY
 
@@ -233,7 +232,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "Letting test client run for %d seconds to produce metric data",
                 TEST_RUN_SECS,
             )
-            if self.server_runner.should_collect_logs:
+            if self.server_runner.should_collect_logs_prometheus:
                 self._sleep_and_ping_prometheus_endpoint(
                     test_server, test_client
                 )

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -32,7 +32,6 @@ from framework.helpers import skips
 from framework.test_app.runners.k8s import gamma_server_runner
 from framework.test_app.runners.k8s import k8s_base_runner
 from framework.test_app.runners.k8s import k8s_xds_client_runner
-from framework.test_app.runners.k8s import k8s_xds_server_runner
 
 logger = logging.getLogger(__name__)
 flags.adopt_module_key_flags(xds_k8s_testcase)


### PR DESCRIPTION
- Created a new test `app_net_csm_observability_test.py` that's largely a copy of `gamma/csm_observability_test.py` with some adjustments.
- Refactor some flags to be passed to the `k8s_xds_server_runner`.
- Use `ServerDeploymentArgs` everywhere

This PR was based on top of #33, and a replacement of #72.
