### PR TITLE
CSM O11y: Enable Python

### DIFF
--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -176,9 +176,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang == _Lang.CPP:
             return config.version_gte("v1.62.x")
-        elif config.client_lang in _Lang.GO | _Lang.JAVA:
-            return config.version_gte("v1.65.x")
-        elif config.client_lang == _Lang.PYTHON:
+        elif config.client_lang in _Lang.GO | _Lang.JAVA | _Lang.PYTHON:
             return config.version_gte("v1.65.x")
         return False
 

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -304,8 +304,9 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_client.hostname,
             }
-            if self.lang_spec.client_lang == _Lang.PYTHON:
-                self.remove_otel_scope_labels(expected_metric_labels)
+            self.filter_label_based_on_lang(
+                self.lang_spec.client_lang, expected_metric_labels
+            )
             for metric in HISTOGRAM_CLIENT_METRICS:
                 actual_metric_labels = all_results[metric].metric_labels
                 self.assertDictEqual(
@@ -331,8 +332,9 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_server.hostname,
             }
-            if self.lang_spec.server_lang == _Lang.PYTHON:
-                self.remove_otel_scope_labels(expected_metric_labels)
+            self.filter_label_based_on_lang(
+                self.lang_spec.server_lang, expected_metric_labels
+            )
             for metric in HISTOGRAM_SERVER_METRICS:
                 actual_metric_labels = all_results[metric].metric_labels
                 self.assertDictEqual(
@@ -349,8 +351,9 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_client.hostname,
             }
-            if self.lang_spec.client_lang == _Lang.PYTHON:
-                self.remove_otel_scope_labels(expected_metric_labels)
+            self.filter_label_based_on_lang(
+                self.lang_spec.client_lang, expected_metric_labels
+            )
             for metric in COUNTER_CLIENT_METRICS:
                 actual_metric_labels = all_results[metric].metric_labels
                 self.assertDictEqual(
@@ -366,8 +369,9 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_server.hostname,
             }
-            if self.lang_spec.server_lang == _Lang.PYTHON:
-                self.remove_otel_scope_labels(expected_metric_labels)
+            self.filter_label_based_on_lang(
+                self.lang_spec.server_lang, expected_metric_labels
+            )
             for metric in COUNTER_SERVER_METRICS:
                 actual_metric_labels = all_results[metric].metric_labels
                 self.assertDictEqual(
@@ -470,16 +474,18 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         )
 
     @staticmethod
-    def remove_otel_scope_labels(labels: dict[str, Any]) -> None:
+    def filter_label_based_on_lang(
+        language: _Lang, labels: dict[str, Any]
+    ) -> None:
         """
-        Removes the 'otel_scope_version' and 'otel_scope_name' from the labels to check.
-
-        TODO(xuanwn): Remove this once https://github.com/open-telemetry/opentelemetry-python/issues/3072 is fixed.
+        Filter labels to check based on language.
         """
-        if "otel_scope_version" in labels:
-            del labels["otel_scope_version"]
-        if "otel_scope_name" in labels:
-            del labels["otel_scope_name"]
+        if language == _Lang.PYTHON:
+            # TODO(xuanwn): Remove this once https://github.com/open-telemetry/opentelemetry-python/issues/3072 is fixed.
+            if "otel_scope_version" in labels:
+                del labels["otel_scope_version"]
+            if "otel_scope_name" in labels:
+                del labels["otel_scope_name"]
 
     def query_metrics(
         self,

--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -304,7 +304,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_client.hostname,
             }
-            self.filter_label_based_on_lang(
+            self.filter_label_matcher_based_on_lang(
                 self.lang_spec.client_lang, expected_metric_labels
             )
             for metric in HISTOGRAM_CLIENT_METRICS:
@@ -332,7 +332,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_server.hostname,
             }
-            self.filter_label_based_on_lang(
+            self.filter_label_matcher_based_on_lang(
                 self.lang_spec.server_lang, expected_metric_labels
             )
             for metric in HISTOGRAM_SERVER_METRICS:
@@ -351,7 +351,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_client.hostname,
             }
-            self.filter_label_based_on_lang(
+            self.filter_label_matcher_based_on_lang(
                 self.lang_spec.client_lang, expected_metric_labels
             )
             for metric in COUNTER_CLIENT_METRICS:
@@ -369,7 +369,7 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
                 "otel_scope_version": ANY,
                 "pod": test_server.hostname,
             }
-            self.filter_label_based_on_lang(
+            self.filter_label_matcher_based_on_lang(
                 self.lang_spec.server_lang, expected_metric_labels
             )
             for metric in COUNTER_SERVER_METRICS:
@@ -473,19 +473,17 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             f'resource.labels.namespace = "{namespace}"'
         )
 
-    @staticmethod
-    def filter_label_based_on_lang(
-        language: _Lang, labels: dict[str, Any]
+    @classmethod
+    def filter_label_matcher_based_on_lang(
+        cls, language: _Lang, label_matcher: dict[str, Any]
     ) -> None:
         """
-        Filter labels to check based on language.
+        Filter label_matcher based on language.
         """
         if language == _Lang.PYTHON:
             # TODO(xuanwn): Remove this once https://github.com/open-telemetry/opentelemetry-python/issues/3072 is fixed.
-            if "otel_scope_version" in labels:
-                del labels["otel_scope_version"]
-            if "otel_scope_name" in labels:
-                del labels["otel_scope_name"]
+            label_matcher.pop("otel_scope_version", None)
+            label_matcher.pop("otel_scope_name", None)
 
     def query_metrics(
         self,


### PR DESCRIPTION
Ad-hoc run:
- [x] [grpc/core/master/linux/psm-csm-python](https://source.cloud.google.com/results/invocations/ba5c2183-34e0-4442-89e9-afd65eff94b1)

### Note
* Removed `otel_scope_name` and `otel_scope_version` tag for Python because python Prometheus exporter doesn't have them yet: https://github.com/open-telemetry/opentelemetry-python/issues/3072