### PR TITLE
framework core: fixes a case when there are fewer endpoints than backends

### DIFF
--- a/bin/run_td_setup.py
+++ b/bin/run_td_setup.py
@@ -262,7 +262,9 @@ def _cmd_backends_add(td, server_name, server_namespace, server_port):
     )
     td.load_backend_service()
     td.backend_service_add_neg_backends(neg_name, neg_zones)
-    td.wait_for_backends_healthy_status()
+    td.wait_for_backends_healthy_status(
+        replica_count=common.SERVER_REPLICA_COUNT.value
+    )
 
 
 def _cmd_backends_cleanup(td):

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -358,7 +358,8 @@ class ComputeV1(
         retryer = retryers.constant_retryer(
             wait_fixed=datetime.timedelta(seconds=wait_sec),
             timeout=datetime.timedelta(seconds=timeout_sec),
-            check_result=lambda neg: neg and neg.get("size", 0) > 0,
+            # TODO(sergiitk): sergiitk fix this
+            check_result=lambda neg: neg and neg.get("size", 0) >= 0,
         )
         network_endpoint_group = retryer(
             self._retry_load_network_endpoint_group, name, zone

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -71,6 +71,7 @@ class ComputeV1(
         GRPC = enum.auto()
 
     class BackendServiceProtocol(enum.Enum):
+        UNSET = enum.auto()
         HTTP2 = enum.auto()
         GRPC = enum.auto()
 

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -412,6 +412,11 @@ class ComputeV1(
         # pylint: disable=too-many-locals
         if not backends:
             raise ValueError("The list of backends to wait on is empty")
+        if not replica_count:
+            raise ValueError(
+                "The list of backends to wait on can't be populated with 0"
+                " replicas."
+            )
 
         timeout = datetime.timedelta(seconds=timeout_sec)
         retryer = retryers.constant_retryer(

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -14,7 +14,7 @@
 import functools
 import logging
 import random
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 import googleapiclient.errors
 from typing_extensions import TypeAlias
@@ -266,9 +266,12 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
         self.backend_service = None
 
     def backend_service_add_neg_backends(
-        self, name, zones, max_rate_per_endpoint: Optional[int] = None
-    ):
-        logger.info("Waiting for Network Endpoint Groups to load endpoints.")
+        self,
+        name: str,
+        zones: list[str],
+        *,
+        max_rate_per_endpoint: Optional[int] = None,
+    ) -> None:
         self.backends |= self._get_gcp_negs_in_zones(name, zones)
         if not self.backends:
             raise ValueError("Unexpected: no backends were loaded.")
@@ -277,7 +280,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
     def _get_gcp_negs_in_zones(
         self, name: str, zones: list[str]
     ) -> set[NegGcpResource]:
-        logger.info("Waiting for Network Endpoint Groups to load endpoints.")
+        logger.info("Loading Network Endpoint Groups in zones %s.", zones)
         backends: set[NegGcpResource] = set()
         for zone in zones:
             neg = self.compute.wait_for_network_endpoint_group(name, zone)

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -14,7 +14,7 @@
 import functools
 import logging
 import random
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Final, List, Optional
 
 import googleapiclient.errors
 from typing_extensions import TypeAlias
@@ -32,7 +32,8 @@ HealthCheckProtocol = _ComputeV1.HealthCheckProtocol
 ZonalGcpResource = _ComputeV1.ZonalGcpResource
 NegGcpResource: TypeAlias = _ComputeV1.NegGcpResource
 BackendServiceProtocol = _ComputeV1.BackendServiceProtocol
-_BackendGRPC = BackendServiceProtocol.GRPC
+_BackendGRPC: Final[BackendServiceProtocol] = BackendServiceProtocol.GRPC
+_BackendUnset: Final[BackendServiceProtocol] = BackendServiceProtocol.UNSET
 _HealthCheckGRPC = HealthCheckProtocol.GRPC
 
 # Network Security
@@ -58,9 +59,20 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
     resource_prefix: str
     resource_suffix: str
 
+    # Backends
     backends: set[NegGcpResource]
     affinity_backends: set[NegGcpResource]
     alternative_backends: set[NegGcpResource]
+
+    # Backend Serivices
+    backend_service: Optional[GcpResource] = None
+    affinity_backend_service: Optional[GcpResource] = None
+    alternative_backend_service: Optional[GcpResource] = None
+
+    # TODO(sergiitk): move these flags to backend service dataclass
+    backend_service_protocol: BackendServiceProtocol = _BackendUnset
+    affinity_backend_service_protocol: BackendServiceProtocol = _BackendUnset
+    alternative_backend_service_protocol: BackendServiceProtocol = _BackendUnset
 
     # Protected
     _ensure_firewall: bool = False
@@ -119,25 +131,8 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
         # Backends.
         self.backends = set()
-        self.backend_service: Optional[GcpResource] = None
-        # TODO(sergiitk): remove this flag once backend service resource loaded
-        self.backend_service_protocol: Optional[BackendServiceProtocol] = None
-
-        # Alternatice Backends.
         self.alternative_backends = set()
-        self.alternative_backend_service: Optional[GcpResource] = None
-        # TODO(sergiitk): remove this flag once backend service resource loaded
-        self.alternative_backend_service_protocol: Optional[
-            BackendServiceProtocol
-        ] = None
-
-        # Affinity Backends.
         self.affinity_backends = set()
-        self.affinity_backend_service: Optional[GcpResource] = None
-        # TODO(sergiitk): remove this flag once backend service resource loaded
-        self.affinity_backend_service_protocol: Optional[
-            BackendServiceProtocol
-        ] = None
 
     @property
     def network_url(self):

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -54,6 +54,27 @@ TEST_AFFINITY_METADATA_KEY = "xds_md"
 
 
 class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
+    # Constants
+    BACKEND_SERVICE_NAME: Final[str] = "backend-service"
+    AFFINITY_BACKEND_SERVICE_NAME: Final[str] = "backend-service-affinity"
+    ALTERNATIVE_BACKEND_SERVICE_NAME: Final[str] = "backend-service-alt"
+
+    URL_MAP_NAME: Final[str] = "url-map"
+    ALTERNATIVE_URL_MAP_NAME: Final[str] = "url-map-alt"
+
+    URL_MAP_PATH_MATCHER_NAME: Final[str] = "path-matcher"
+
+    TARGET_PROXY_NAME: Final[str] = "target-proxy"
+    ALTERNATIVE_TARGET_PROXY_NAME: Final[str] = "target-proxy-alt"
+
+    FORWARDING_RULE_NAME: Final[str] = "forwarding-rule"
+    ALTERNATIVE_FORWARDING_RULE_NAME: Final[str] = "forwarding-rule-alt"
+
+    HEALTH_CHECK_NAME: Final[str] = "health-check"
+
+    FIREWALL_RULE_NAME: Final[str] = "allow-health-checks"
+    FIREWALL_RULE_NAME_IPV6: Final[str] = "allow-health-checks-ipv6"
+
     # Class fields.
     compute: _ComputeV1
     resource_prefix: str
@@ -76,21 +97,6 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     # Protected
     _ensure_firewall: bool = False
-
-    # Constants
-    BACKEND_SERVICE_NAME = "backend-service"
-    ALTERNATIVE_BACKEND_SERVICE_NAME = "backend-service-alt"
-    AFFINITY_BACKEND_SERVICE_NAME = "backend-service-affinity"
-    HEALTH_CHECK_NAME = "health-check"
-    URL_MAP_NAME = "url-map"
-    ALTERNATIVE_URL_MAP_NAME = "url-map-alt"
-    URL_MAP_PATH_MATCHER_NAME = "path-matcher"
-    TARGET_PROXY_NAME = "target-proxy"
-    ALTERNATIVE_TARGET_PROXY_NAME = "target-proxy-alt"
-    FORWARDING_RULE_NAME = "forwarding-rule"
-    ALTERNATIVE_FORWARDING_RULE_NAME = "forwarding-rule-alt"
-    FIREWALL_RULE_NAME = "allow-health-checks"
-    FIREWALL_RULE_NAME_IPV6 = "allow-health-checks-ipv6"
 
     def __init__(
         self,
@@ -313,9 +319,9 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     def wait_for_backends_healthy_status(self, replica_count: int = 1):
         logger.info(
-            "Waiting for Backend Service %s to report all backends healthy: %r",
+            "Waiting for Backend Service %s to report backends healthy: %r",
             self.backend_service.name,
-            [backend.name for backend in self.backends],
+            self.backends,
         )
         self.compute.wait_for_backends_healthy_status(
             self.backend_service, self.backends, replica_count=replica_count
@@ -364,7 +370,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
         self, *, circuit_breakers: Optional[dict[str, int]] = None
     ):
         logging.info(
-            "Adding backends to Backend Service %s: %r",
+            "Adding backends to Alternative Backend Service %s: %r",
             self.alternative_backend_service.name,
             self.alternative_backends,
         )
@@ -376,7 +382,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     def alternative_backend_service_remove_all_backends(self):
         logging.info(
-            "Removing backends from Backend Service %s",
+            "Removing backends from Alternative Backend Service %s",
             self.alternative_backend_service.name,
         )
         self.compute.backend_service_remove_all_backends(
@@ -387,7 +393,8 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
         self, replica_count: int = 1
     ):
         logger.debug(
-            "Waiting for Backend Service %s to report all backends healthy %r",
+            "Waiting for Alternative Backend Service %s"
+            " to report backends healthy: %r",
             self.alternative_backend_service,
             self.alternative_backends,
         )
@@ -439,7 +446,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     def affinity_backend_service_patch_backends(self):
         logging.info(
-            "Adding backends to Backend Service %s: %r",
+            "Adding backends to Affinity Backend Service %s: %r",
             self.affinity_backend_service.name,
             self.affinity_backends,
         )
@@ -449,7 +456,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     def affinity_backend_service_remove_all_backends(self):
         logging.info(
-            "Removing backends from Backend Service %s",
+            "Removing backends from Affinity Backend Service %s",
             self.affinity_backend_service.name,
         )
         self.compute.backend_service_remove_all_backends(
@@ -458,7 +465,8 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     def wait_for_affinity_backends_healthy_status(self, replica_count: int = 1):
         logger.debug(
-            "Waiting for Backend Service %s to report all backends healthy %r",
+            "Waiting for Affinity Backend Service %s"
+            " to report backends healthy: %r",
             self.affinity_backend_service,
             self.affinity_backends,
         )

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -356,7 +356,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
 
     def alternative_backend_service_add_neg_backends(self, name, zones):
         self.alternative_backends |= self._get_gcp_negs_in_zones(name, zones)
-        if not self.affinity_backends:
+        if not self.alternative_backends:
             raise ValueError("Unexpected: no alternative backends were loaded.")
         self.alternative_backend_service_patch_backends()
 

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -301,14 +301,14 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
         )
         self.compute.backend_service_remove_all_backends(self.backend_service)
 
-    def wait_for_backends_healthy_status(self):
+    def wait_for_backends_healthy_status(self, replica_count: int = 1):
         logger.info(
             "Waiting for Backend Service %s to report all backends healthy: %r",
             self.backend_service.name,
             [backend.name for backend in self.backends],
         )
         self.compute.wait_for_backends_healthy_status(
-            self.backend_service, self.backends
+            self.backend_service, self.backends, replica_count=replica_count
         )
 
     def create_alternative_backend_service(

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -377,14 +377,18 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
             self.alternative_backend_service
         )
 
-    def wait_for_alternative_backends_healthy_status(self):
+    def wait_for_alternative_backends_healthy_status(
+        self, replica_count: int = 1
+    ):
         logger.debug(
             "Waiting for Backend Service %s to report all backends healthy %r",
             self.alternative_backend_service,
             self.alternative_backends,
         )
         self.compute.wait_for_backends_healthy_status(
-            self.alternative_backend_service, self.alternative_backends
+            self.alternative_backend_service,
+            self.alternative_backends,
+            replica_count=replica_count,
         )
 
     def create_affinity_backend_service(
@@ -450,14 +454,16 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
             self.affinity_backend_service
         )
 
-    def wait_for_affinity_backends_healthy_status(self):
+    def wait_for_affinity_backends_healthy_status(self, replica_count: int = 1):
         logger.debug(
             "Waiting for Backend Service %s to report all backends healthy %r",
             self.affinity_backend_service,
             self.affinity_backends,
         )
         self.compute.wait_for_backends_healthy_status(
-            self.affinity_backend_service, self.affinity_backends
+            self.affinity_backend_service,
+            self.affinity_backends,
+            replica_count=replica_count,
         )
 
     @staticmethod

--- a/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -71,6 +71,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
 
     # Below is mutable state associated with the current run.
     service: Optional[k8s.V1Service] = None
+    replica_count: int = 0
 
     # A map from pod names to the server app.
     pods_to_servers: dict[str, XdsTestServer]
@@ -151,6 +152,7 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
         super()._reset_state()
         self.service = None
         self.pods_to_servers = {}
+        self.replica_count = 0
 
     def run(  # pylint: disable=arguments-differ,too-many-branches
         self,
@@ -278,6 +280,8 @@ class KubernetesServerRunner(k8s_base_runner.KubernetesBaseRunner):
             self.deployment_name, replica_count
         )
         self._start_completed()
+        # TODO(sergiitk): move to super()._start_completed
+        self.replica_count = replica_count
 
         servers: List[XdsTestServer] = []
         for pod in self.pods_started.values():

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -343,7 +343,9 @@ class XdsKubernetesBaseTestCase(base_testcase.BaseTestCase):
             neg_name, neg_zones, max_rate_per_endpoint=max_rate_per_endpoint
         )
         if wait_for_healthy_status:
-            self.td.wait_for_backends_healthy_status()
+            self.td.wait_for_backends_healthy_status(
+                replica_count=server_runner.replica_count
+            )
 
     def removeServerBackends(self, *, server_runner=None):
         if server_runner is None:

--- a/framework/xds_url_map_test_resources.py
+++ b/framework/xds_url_map_test_resources.py
@@ -15,7 +15,7 @@
 
 import functools
 import inspect
-from typing import Any, Iterable, Mapping, Tuple
+from typing import Any, Final, Iterable, Mapping, Tuple
 
 from absl import flags
 from absl import logging
@@ -140,6 +140,12 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
     All resources are intended to be used across test cases and multiple runs
     (except the client K8s deployment).
     """
+
+    TEST_SERVER_REPLICA_COUNT: Final[int] = 1
+    TEST_SERVER_ALTERNATIVE_REPLICA_COUNT: Final[int] = 1
+    # Kubernetes Test Server Affinity: 3 endpoints to test that only the picked
+    # sub-channel is connected.
+    TEST_SERVER_AFFINITY_REPLICA_COUNT: Final[int] = 3
 
     # This class dynamically set, so disable "no-member" check.
     # pylint: disable=no-member
@@ -297,18 +303,20 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         self.test_server_runner.run(
             test_port=self.server_port,
             maintenance_port=self.server_maintenance_port,
+            replica_count=self.TEST_SERVER_REPLICA_COUNT,
         )
         # Kubernetes Test Server Alternative
         self.test_server_alternative_runner.run(
             test_port=self.server_port,
             maintenance_port=self.server_maintenance_port,
+            replica_count=self.TEST_SERVER_ALTERNATIVE_REPLICA_COUNT,
         )
         # Kubernetes Test Server Affinity. 3 endpoints to test that only the
         # picked sub-channel is connected.
         self.test_server_affinity_runner.run(
             test_port=self.server_port,
             maintenance_port=self.server_maintenance_port,
-            replica_count=3,
+            replica_count=self.TEST_SERVER_AFFINITY_REPLICA_COUNT,
         )
         # Add backend to default backend service
         neg_name, neg_zones = self.k8s_namespace.parse_service_neg_status(
@@ -337,13 +345,13 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
         )
         # Wait for healthy backends
         self.td.wait_for_backends_healthy_status(
-            replica_count=self.test_server_runner.replica_count
+            replica_count=self.TEST_SERVER_REPLICA_COUNT,
         )
         self.td.wait_for_alternative_backends_healthy_status(
-            replica_count=self.test_server_alternative_runner.replica_count
+            replica_count=self.TEST_SERVER_ALTERNATIVE_REPLICA_COUNT,
         )
         self.td.wait_for_affinity_backends_healthy_status(
-            replica_count=self.test_server_affinity_runner.replica_count
+            replica_count=self.TEST_SERVER_AFFINITY_REPLICA_COUNT,
         )
 
     def cleanup(self) -> None:

--- a/framework/xds_url_map_test_resources.py
+++ b/framework/xds_url_map_test_resources.py
@@ -336,9 +336,15 @@ class GcpResourceManager(metaclass=_MetaSingletonAndAbslFlags):
             neg_name_affinity, neg_zones_affinity
         )
         # Wait for healthy backends
-        self.td.wait_for_backends_healthy_status()
-        self.td.wait_for_alternative_backends_healthy_status()
-        self.td.wait_for_affinity_backends_healthy_status()
+        self.td.wait_for_backends_healthy_status(
+            replica_count=self.test_server_runner.replica_count
+        )
+        self.td.wait_for_alternative_backends_healthy_status(
+            replica_count=self.test_server_alternative_runner.replica_count
+        )
+        self.td.wait_for_affinity_backends_healthy_status(
+            replica_count=self.test_server_affinity_runner.replica_count
+        )
 
     def cleanup(self) -> None:
         if self.strategy not in ["create"]:


### PR DESCRIPTION
Fixes an issue with NEG size and Backend Health waiting logic.

This bug has been in the framework from the very beginning, because we never tested the flow with (a) Regional or multizonal cluster, AND (b) a single server.

The issue: when GKE cluster has nodes in more than one zone, a NEG for the test server/service is created in each zone. If there's fewer endpoints than zones in the cluster, not every NEG will end up having a server endpoint. Therefore:

1. `wait_for_network_endpoint_group` will fail because it waits for every NEG to have more than 0 endpoints.
2. `wait_for_backends_healthy_status` will fail because NEGs with 0 endpoints will never be marked as healthy.

This PR changes the logic of:
1. `wait_for_network_endpoint_group` now waits for a NEG to merely exist in GCP APIs.
2. `wait_for_backends_healthy_status` now accounts for server replica_count and will succeeded as soon as the number of healthy Backends to be greater or equal the number of server replicas.

Discovered when debugging #86. Splitting to its own PR.