### PR TITLE
csm: Pass value to argument --enable_csm_observability

### DIFF
--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -49,7 +49,7 @@ spec:
             % endif
             - "--print_response=${print_response}"
             % if enable_csm_observability:
-            - "--enable_csm_observability"
+            - "--enable_csm_observability=true"
             % endif
           ports:
             - containerPort: ${stats_port}

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             - "--port=${test_port}"
             % if enable_csm_observability:
-            - "--enable_csm_observability"
+            - "--enable_csm_observability=true"
             % endif
           ports:
             - containerPort: ${test_port}


### PR DESCRIPTION
This is needed by the Java client/server, because there's a simplistic parsing implementation. Since we need the parsing to work cross-language, we always include a value. `--secure_mode` and `--fail_on_failed_rpcs` (unused by this framework, but defined in xds-test-descriptions.md) are both boolean flags that we pass a value.