### PR TITLE
CSM O11y: Enable Java

### DIFF
--- a/tests/gamma/csm_observability_test.py
+++ b/tests/gamma/csm_observability_test.py
@@ -177,6 +177,8 @@ class CsmObservabilityTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
             return config.version_gte("v1.62.x")
         elif config.client_lang == _Lang.GO:
             return config.version_gte("v1.65.x")
+        elif config.client_lang == _Lang.JAVA:
+            return config.version_gte("v1.65.x")
         return False
 
     @classmethod


### PR DESCRIPTION
Enable CSM Observability tests for Java >= 1.65.x

This is dependent on #94