### PR TITLE
Bump server_image_canonical from java v1.56 to v1.65

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -348,7 +348,7 @@ psm::run::test() {
     PSM_TEST_FLAGS+=("--server_image=${SERVER_IMAGE_NAME}:${GIT_COMMIT}")
   elif [[ "${GRPC_LANGUAGE}" == "node"  ]]; then
     # TODO(b/261911148): To be replaced with --server_image_use_canonical when implemented.
-    PSM_TEST_FLAGS+=("--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical")
+    PSM_TEST_FLAGS+=("--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65")
   fi
 
   # So far, only LB test uses secondary GKE cluster.

--- a/config/common.cfg
+++ b/config/common.cfg
@@ -4,8 +4,8 @@
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,
 # or missing a feature required for the test.
-# TODO(sergiitk): Update every ~ 6 months; next 2024-01.
---server_image_canonical=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.56
+# TODO(sergiitk): Update every ~ 6 months; next 2025-01.
+--server_image_canonical=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65
 
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/config/url-map.cfg
+++ b/config/url-map.cfg
@@ -7,7 +7,7 @@
 # 2. All UrlMap tests today are testing client-side logic.
 #
 # TODO(sergiitk): Use --server_image_canonical instead.
---server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.56
+--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65
 
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None


### PR DESCRIPTION
Default `--server_image_canonical` updated:
- From: http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.56 ([sha](http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server@sha256:21124ccfb63b5c348f23102c00784f6b673b933fe03df3445497734532c82a05))
- To: http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65 

Image `java-server:canonical-v1.65` created from commit grpc/grpc-java@3c97245ae480d1afd28f9c03c12988b52b2bf6ba, branch [v1.65.x](https://github.com/grpc/grpc-java/tree/v1.65.x) - http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:3c97245ae480d1afd28f9c03c12988b52b2bf6ba ([sha](http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server@sha256:3ce3f0ab808ee6f16763a2cce6ff239a1a165965b4b667f03e6c47933973048b)).

Image [`java-server:canonical`](http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical) bumped from http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:ed73755da838d66f06d5ab57464fa553bfe24001 ([sha](http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server@sha256:21124ccfb63b5c348f23102c00784f6b673b933fe03df3445497734532c82a05)) to http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:3c97245ae480d1afd28f9c03c12988b52b2bf6ba ([sha](http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server@sha256:3ce3f0ab808ee6f16763a2cce6ff239a1a165965b4b667f03e6c47933973048b)).

Corresponding cl: cl/646617849.