### PR TITLE
csm: skip grpcroute test until clusters are updated to the right state

### DIFF
--- a/tests/gamma/gamma_grpcroute_test.py
+++ b/tests/gamma/gamma_grpcroute_test.py
@@ -36,7 +36,7 @@ class GammaGrpcRouteTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     ) -> gamma_server_runner.GammaServerRunner:
         kwargs["route_kind"] = k8s.RouteKind.GRPC
         return super().initKubernetesServerRunner(**kwargs)
-    
+
     @absltest.unittest.skip("Skipping test until cl/655674720 is merged")
     def test_ping_pong(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma

--- a/tests/gamma/gamma_grpcroute_test.py
+++ b/tests/gamma/gamma_grpcroute_test.py
@@ -36,7 +36,8 @@ class GammaGrpcRouteTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     ) -> gamma_server_runner.GammaServerRunner:
         kwargs["route_kind"] = k8s.RouteKind.GRPC
         return super().initKubernetesServerRunner(**kwargs)
-
+    
+    @absltest.unittest.skip("Skipping test until cl/655674720 is merged")
     def test_ping_pong(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma
         #   resource creation out of self.startTestServers()


### PR DESCRIPTION
cc: @sergiitk 

This need not be merged in until the rollout to prod of the change begins