### PR TITLE
Kokoro: fix dualstack test name

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -176,7 +176,7 @@ psm::dualstack::setup() {
 #######################################
 psm::dualstack::get_tests() {
   TESTS=(
-    "test_dualstack"
+    "dualstack_test"
   )
 }
 


### PR DESCRIPTION
`test_dualstack` -> `dualstack_test`