### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grpc/grpc-psm-interop


### PR DESCRIPTION
This is to solve the issue with the `@grpc/grpc-psm-interop-all` (Triage access)  being unable to resolve conversations when reviewing pull requests (https://github.com/orgs/community/discussions/12961).

The idea is to
- Create `@grpc/grpc-psm-interop-review` and grant Write access to the repo
- Configure `main` branch to require PRs to be approved by a code owner [`@grpc/grpc-psm-interop`](https://github.com/orgs/grpc/teams/grpc-psm-interop)
- Configure `@grpc/grpc-psm-interop` to only not send notifications to folks that don't actively work on the framework. They still keep the right of the final sign-off, but won't be bugged by each PR review request:

![image](https://github.com/user-attachments/assets/de5b17d8-7c7f-4f56-9218-c590ce825927)


 