### PR TITLE
Bump server_image_canonical server from java v1.65 to v1.66

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -392,7 +392,7 @@ psm::run::test() {
     PSM_TEST_FLAGS+=("--server_image=${SERVER_IMAGE_NAME}:${GIT_COMMIT}")
   elif [[ "${GRPC_LANGUAGE}" == "node"  ]]; then
     # TODO(b/261911148): To be replaced with --server_image_use_canonical when implemented.
-    PSM_TEST_FLAGS+=("--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65")
+    PSM_TEST_FLAGS+=("--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.66")
   fi
 
   # So far, only LB test uses secondary GKE cluster.

--- a/config/common.cfg
+++ b/config/common.cfg
@@ -5,7 +5,7 @@
 # Can be used in tests where language-specific xDS test server does not exist,
 # or missing a feature required for the test.
 # TODO(sergiitk): Update every ~ 6 months; next 2025-01.
---server_image_canonical=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65
+--server_image_canonical=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.66
 
 --logger_levels=__main__:DEBUG,framework:INFO
 --verbosity=0

--- a/config/url-map.cfg
+++ b/config/url-map.cfg
@@ -7,7 +7,7 @@
 # 2. All UrlMap tests today are testing client-side logic.
 #
 # TODO(sergiitk): Use --server_image_canonical instead.
---server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65
+--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.66
 
 # Disables the GCP Workload Identity feature to simplify permission control
 --gcp_service_account=None


### PR DESCRIPTION
Default --server_image_canonical updated:

* From: http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.65
* To: http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.66

Image java-server:canonical-v1.65 created from commit https://github.com/grpc/grpc-java/commit/3c97245ae480d1afd28f9c03c12988b52b2bf6ba, branch [v1.65.x](https://github.com/grpc/grpc-java/tree/v1.65.x) - http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:3c97245ae480d1afd28f9c03c12988b52b2bf6ba ([sha](http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server@sha256:3ce3f0ab808ee6f16763a2cce6ff239a1a165965b4b667f03e6c47933973048b)).

Image java-server:canonical-v1.66 created from commit https://github.com/grpc/grpc-java/commit/6043b0c166cb53104cd21a2e7f75edac09c579012226642d476db00944b0c0b7, branch [v1.66.x](https://github.com/grpc/grpc-java/tree/v1.66.x) - http://us-docker.pkg.dev/grpc-testing/psm-interop/java-server:ef09d94fe8d51aca13f3490f599ebbfabf3299ab ([sha](https://pantheon.corp.google.com/artifacts/docker/grpc-testing/us/psm-interop/java-server/sha256:6043b0c166cb53104cd21a2e7f75edac09c579012226642d476db00944b0c0b7)).




Corresponding cl: cl/658515573