### PR TITLE
fixed syntax error

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -208,6 +208,7 @@ psm::dualstack::run_test() {
 # Fallback Test Suite setup.
 #######################################
 psm::fallback::setup() {
+  : # Placeholder for future setup commands
 }
 
 #######################################


### PR DESCRIPTION
This PR fixes the syntax error caused by [this](https://github.com/grpc/psm-interop/pull/119) PR which is causing all the test runs to fail.