### PR TITLE
Add cluster for a fallback test

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -207,10 +207,10 @@ psm::dualstack::run_test() {
 #######################################
 # Fallback Test Suite setup.
 #
-# This test does not actively need GKE but Kokoro fails if no cluster is provided.
+# This test does not need GKE so setting variable to skip some init
 #######################################
 psm::fallback::setup() {
-  activate_gke_cluster GKE_CLUSTER_PSM_BASIC
+  NO_GKE_CLUSTER=1
 }
 
 #######################################
@@ -913,6 +913,10 @@ gcloud_gcr_list_image_tags() {
 #   Writes authorization info $HOME/.kube/config
 #######################################
 gcloud_get_cluster_credentials() {
+  if [[ -n "NO_GKE_CLUSTER" ]]; then
+    psm::tools::log "Skipping cluster credentials"
+    return
+  fi
   # Secondary cluster, when set.
   if [[ -n "${SECONDARY_GKE_CLUSTER_NAME}" && -n "${SECONDARY_GKE_CLUSTER_ZONE}" ]]; then
     gcloud container clusters get-credentials "${SECONDARY_GKE_CLUSTER_NAME}" --zone "${SECONDARY_GKE_CLUSTER_ZONE}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -209,7 +209,7 @@ psm::dualstack::run_test() {
 #
 # This test does not actively need GKE but Kokoro fails if no cluster is provided.
 #######################################
-psm::url_map::setup() {
+psm::fallback::setup() {
   activate_gke_cluster GKE_CLUSTER_PSM_BASIC
 }
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -206,9 +206,11 @@ psm::dualstack::run_test() {
 
 #######################################
 # Fallback Test Suite setup.
+#
+# This test does not actively need GKE but Kokoro fails if no cluster is provided.
 #######################################
-psm::fallback::setup() {
-  : # Placeholder for future setup commands
+psm::url_map::setup() {
+  activate_gke_cluster GKE_CLUSTER_PSM_BASIC
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -913,7 +913,7 @@ gcloud_gcr_list_image_tags() {
 #   Writes authorization info $HOME/.kube/config
 #######################################
 gcloud_get_cluster_credentials() {
-  if [[ -n "NO_GKE_CLUSTER" ]]; then
+  if [[ -n "${NO_GKE_CLUSTER}" ]]; then
     psm::tools::log "Skipping cluster credentials"
     return
   fi


### PR DESCRIPTION
Trying to address this Kokoro failure:
```
+ [21:10:41 UTC]	 Installing packages with apt, see install-apt.log
+ [21:11:21 UTC]	 Fetching GKE cluster credentials
ERROR: (gcloud.container.clusters.get-credentials) One of [--location, --zone, --region] must be supplied.
```