### PR TITLE
Authenticate with a Docker registry

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -211,6 +211,7 @@ psm::dualstack::run_test() {
 #######################################
 psm::fallback::setup() {
   NO_GKE_CLUSTER=1
+  gcloud -q auth configure-docker "${DOCKER_REGISTRY}"
 }
 
 #######################################


### PR DESCRIPTION
This looks like the last missing piece. I was able to run test to a completion on Kokoro with this patch.

[Successful Run](https://fusion2.corp.google.com/invocations/aeee37d0-a500-4b6f-bc3e-209765139bc9/log)