### PR TITLE
[compute] Add a flag to force API key parameter in v2 Discovery APIs

### DIFF
--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -119,7 +119,9 @@ class GcpApiManager:
         # TODO(sergiitk): add options to pass google Credentials
         self._exit_stack = contextlib.ExitStack()
 
-        self.v2_discovery_force_api_key = v2_discovery_force_api_key
+        self.v2_discovery_force_api_key = (
+            v2_discovery_force_api_key or V2_DISCOVERY_FORCE_API_KEY.value
+        )
 
     def close(self):
         self._exit_stack.close()
@@ -184,14 +186,7 @@ class GcpApiManager:
                 visibility_labels=["NETWORKSECURITY_ALPHA"],
             )
         elif version == "v1beta1":
-            add_args = {}
-            if (
-                self.v2_discovery_force_api_key
-                or V2_DISCOVERY_FORCE_API_KEY.value
-            ):
-                add_args["api_key"] = self.private_api_key
-
-            return self._build_from_discovery_v2(api_name, version, **add_args)
+            return self._build_from_discovery_v2(api_name, version)
 
         raise NotImplementedError(f"Network Security {version} not supported")
 
@@ -206,14 +201,7 @@ class GcpApiManager:
                 visibility_labels=["NETWORKSERVICES_ALPHA"],
             )
         elif version in ("v1", "v1beta1"):
-            add_args = {}
-            if (
-                self.v2_discovery_force_api_key
-                or V2_DISCOVERY_FORCE_API_KEY.value
-            ):
-                add_args["api_key"] = self.private_api_key
-
-            return self._build_from_discovery_v2(api_name, version, **add_args)
+            return self._build_from_discovery_v2(api_name, version)
 
         raise NotImplementedError(f"Network Services {version} not supported")
 
@@ -281,6 +269,9 @@ class GcpApiManager:
         params = {}
         if api_key:
             params["key"] = api_key
+        elif self.v2_discovery_force_api_key:
+            params["key"] = self.private_api_key
+
         if visibility_labels:
             # Dash-separated list of labels.
             params["labels"] = "_".join(visibility_labels)

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -54,7 +54,7 @@ V2_DISCOVERY_URI = flags.DEFINE_string(
     default=discovery.V2_DISCOVERY_URI,
     help="Override v2 Discovery URI",
 )
-V2_DISCOVERY_FORCE_API_KEY = flags.DEFINE_string(
+V2_DISCOVERY_FORCE_API_KEY = flags.DEFINE_boolean(
     "v2_discovery_force_api_key",
     default=False,
     help=(

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -54,6 +54,14 @@ V2_DISCOVERY_URI = flags.DEFINE_string(
     default=discovery.V2_DISCOVERY_URI,
     help="Override v2 Discovery URI",
 )
+V2_DISCOVERY_FORCE_API_KEY = flags.DEFINE_string(
+    "v2_discovery_force_api_key",
+    default=False,
+    help=(
+        "Set flag to add API key when accessing staging networksecurity, "
+        "networkservices endpoints"
+    ),
+)
 COMPUTE_V1_DISCOVERY_FILE = flags.DEFINE_string(
     "compute_v1_discovery_file",
     default=None,
@@ -91,6 +99,7 @@ class GcpApiManager:
         private_api_key_secret_name=None,
         gcp_ui_url=None,
         verbose_gcp_api: bool = False,
+        v2_discovery_force_api_key: bool = False,
     ):
         # Log GCP API requests and responses.
         # Note: this modifies a global variable on googleapiclient.model.
@@ -109,6 +118,8 @@ class GcpApiManager:
         self.gcp_ui_url = gcp_ui_url or GCP_UI_URL.value
         # TODO(sergiitk): add options to pass google Credentials
         self._exit_stack = contextlib.ExitStack()
+
+        self.v2_discovery_force_api_key = v2_discovery_force_api_key
 
     def close(self):
         self._exit_stack.close()
@@ -173,7 +184,14 @@ class GcpApiManager:
                 visibility_labels=["NETWORKSECURITY_ALPHA"],
             )
         elif version == "v1beta1":
-            return self._build_from_discovery_v2(api_name, version)
+            add_args = {}
+            if (
+                self.v2_discovery_force_api_key
+                or V2_DISCOVERY_FORCE_API_KEY.value
+            ):
+                add_args["api_key"] = self.private_api_key
+
+            return self._build_from_discovery_v2(api_name, version, **add_args)
 
         raise NotImplementedError(f"Network Security {version} not supported")
 
@@ -188,7 +206,14 @@ class GcpApiManager:
                 visibility_labels=["NETWORKSERVICES_ALPHA"],
             )
         elif version in ("v1", "v1beta1"):
-            return self._build_from_discovery_v2(api_name, version)
+            add_args = {}
+            if (
+                self.v2_discovery_force_api_key
+                or V2_DISCOVERY_FORCE_API_KEY.value
+            ):
+                add_args["api_key"] = self.private_api_key
+
+            return self._build_from_discovery_v2(api_name, version, **add_args)
 
         raise NotImplementedError(f"Network Services {version} not supported")
 


### PR DESCRIPTION
Added an additional flag to include API key when invoking staging networkservices and networksecurity endpoints.

ref b/360284595