### PR TITLE
Run part of LB tests on Dualstack cluster

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -75,8 +75,6 @@ psm::lb::setup() {
 psm::lb::get_tests() {
   TESTS=(
     "failover_test"
-    "outlier_detection_test"
-    "remove_neg_test"
   )
 }
 
@@ -169,6 +167,8 @@ psm::dualstack::get_tests() {
     "custom_lb_test"
     "round_robin_test"
     "circuit_breaking_test"
+    "outlier_detection_test"
+    "remove_neg_test"
   )
   # master-only tests
   if [[ "${TESTING_VERSION}" =~ "master" ]]; then

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -74,8 +74,25 @@ psm::lb::setup() {
 #######################################
 psm::lb::get_tests() {
   TESTS=(
+    "affinity_test"
+    "api_listener_test"
+    "app_net_test"
+    "change_backend_service_test"
+    "custom_lb_test"
     "failover_test"
+    "outlier_detection_test"
+    "remove_neg_test"
+    "round_robin_test"
+    "circuit_breaking_test"
   )
+  # master-only tests
+  if [[ "${TESTING_VERSION}" =~ "master" ]]; then
+      psm::tools::log "Appending master-only tests to the LB suite."
+      TESTS+=(
+        "bootstrap_generator_test"
+        "subsetting_test"
+      )
+  fi
 }
 
 #######################################

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -74,25 +74,10 @@ psm::lb::setup() {
 #######################################
 psm::lb::get_tests() {
   TESTS=(
-    "affinity_test"
-    "api_listener_test"
-    "app_net_test"
-    "change_backend_service_test"
-    "custom_lb_test"
     "failover_test"
     "outlier_detection_test"
     "remove_neg_test"
-    "round_robin_test"
-    "circuit_breaking_test"
   )
-  # master-only tests
-  if [[ "${TESTING_VERSION}" =~ "master" ]]; then
-      psm::tools::log "Appending master-only tests to the LB suite."
-      TESTS+=(
-        "bootstrap_generator_test"
-        "subsetting_test"
-      )
-  fi
 }
 
 #######################################
@@ -177,7 +162,22 @@ psm::dualstack::setup() {
 psm::dualstack::get_tests() {
   TESTS=(
     "dualstack_test"
+    "affinity_test"
+    "api_listener_test"
+    "app_net_test"
+    "change_backend_service_test"
+    "custom_lb_test"
+    "round_robin_test"
+    "circuit_breaking_test"
   )
+  # master-only tests
+  if [[ "${TESTING_VERSION}" =~ "master" ]]; then
+      psm::tools::log "Appending master-only tests to the LB suite."
+      TESTS+=(
+        "bootstrap_generator_test"
+        "subsetting_test"
+      )
+  fi
 }
 
 #######################################


### PR DESCRIPTION
This PR enables some of the LB tests to run on dualstack cluster.

Logs from local run are available [here](http://fusion2/13ec7af4-f79c-4b8f-ab6f-5d9e573e960c).