### PR TITLE
Exclude remove_neg_test from Dualstack test suite

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -185,7 +185,6 @@ psm::dualstack::get_tests() {
     "round_robin_test"
     "circuit_breaking_test"
     "outlier_detection_test"
-    "remove_neg_test"
   )
 }
 


### PR DESCRIPTION
Reverting part of [this](https://github.com/grpc/psm-interop/pull/130) commit, as `remove_neg_test` is causing failure in dualstack test suite.