### PR TITLE
Drop python3.9, require python3.10 minimum

### DIFF
--- a/.github/workflows/psm-interop.yaml
+++ b/.github/workflows/psm-interop.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11"]
       fail-fast: false
     permissions:
       pull-requests: read  # Used by paths-filter to read the diff.
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: 'pip'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ changes to this codebase at the moment.
 ## Installation
 
 #### Requirements
-1. Python v3.9+
+1. Python v3.10+
 2. [Google Cloud SDK](https://cloud.google.com/sdk/docs/install)
 3. `kubectl`
 

--- a/bin/pylint.sh
+++ b/bin/pylint.sh
@@ -29,7 +29,7 @@ USAGE:
   ./bin/pylint.sh
 
 ONE-TIME INSTALLATION:
-  1. python3.9 -m venv --upgrade-deps venv-pylint
+  1. python3.10 -m venv --upgrade-deps venv-pylint
   2. source ./venv-pylint/bin/activate
   3. pip install pylint==2.2.2 astroid==2.3.3 toml==0.10.2 "isort>=4.3.0,<5.0.0"
   4. deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.black]
 line-length = 80
 target-version = [
-  "py39",
   "py310",
   "py311",
 ]


### PR DESCRIPTION
python3.10 is now the minimal required version (used by Kokoro tests).

Related:
- cl/370095649
- b/370095649