### PR TITLE
minor: Use native TypeAlias

### DIFF
--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -15,10 +15,9 @@
 import collections
 import dataclasses
 import functools
-from typing import Optional
+from typing import Optional, TypeAlias
 
 import grpc
-from typing_extensions import TypeAlias
 import yaml
 
 from framework.rpc import grpc_testing

--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -21,7 +21,7 @@ import json
 import logging
 import pathlib
 import threading
-from typing import Any, Callable, Final, List, Optional, Tuple, Union
+from typing import Any, Callable, Final, List, Optional, Tuple, TypeAlias, Union
 import warnings
 
 from kubernetes import client
@@ -30,7 +30,7 @@ from kubernetes import utils
 import kubernetes.config
 from kubernetes.dynamic import exceptions as dynamic_exc
 from kubernetes.dynamic import resource as dynamic_res
-from typing_extensions import Self, TypeAlias, override
+from typing_extensions import Self, override
 import urllib3.exceptions
 import yaml
 

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -14,10 +14,9 @@
 import functools
 import logging
 import random
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, List, Optional, TypeAlias
 
 import googleapiclient.errors
-from typing_extensions import TypeAlias
 
 from framework import xds_flags
 from framework.infrastructure import gcp

--- a/framework/rpc/grpc_csds.py
+++ b/framework/rpc/grpc_csds.py
@@ -19,10 +19,9 @@ import datetime as dt
 import json
 import logging
 import re
-from typing import Any, Final, Optional, Type, cast
+from typing import Any, Final, Optional, Type, TypeAlias, cast
 
 from google.protobuf import json_format
-from typing_extensions import TypeAlias
 
 # Needed to load the descriptors so that Any is parsed
 # TODO(sergiitk): replace with import xds_protos when it works

--- a/framework/rpc/grpc_testing.py
+++ b/framework/rpc/grpc_testing.py
@@ -18,13 +18,12 @@ https://github.com/grpc/grpc/blob/master/src/proto/grpc/testing/test.proto
 from collections.abc import Sequence
 import datetime as dt
 import logging
-from typing import Any, Final, Optional, cast
+from typing import Any, Final, Optional, TypeAlias, cast
 
 from google.protobuf import json_format
 import grpc
 from grpc_health.v1 import health_pb2
 from grpc_health.v1 import health_pb2_grpc
-from typing_extensions import TypeAlias
 
 import framework.rpc
 from protos.grpc.testing import empty_pb2

--- a/framework/test_cases/session_affinity_mixin.py
+++ b/framework/test_cases/session_affinity_mixin.py
@@ -20,9 +20,7 @@ networkservices.googleapis.com API.
 """
 import datetime as dt
 import logging
-from typing import Final, Sequence, Union
-
-from typing_extensions import TypeAlias
+from typing import Final, Sequence, TypeAlias, Union
 
 from framework import xds_k8s_testcase
 from framework.helpers import retryers

--- a/tests/app_net_ssa_test.py
+++ b/tests/app_net_ssa_test.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Final, List, Optional
+from typing import Final, List, Optional, TypeAlias
 
 from absl import flags
 from absl.testing import absltest
-from typing_extensions import TypeAlias
 
 from framework import xds_k8s_testcase
 from framework.helpers import skips

--- a/tests/dualstack_test.py
+++ b/tests/dualstack_test.py
@@ -17,7 +17,7 @@ from typing import Final
 
 from absl import flags
 from absl.testing import absltest
-from typing_extensions import TypeAlias, override
+from typing_extensions import override
 
 from framework import xds_k8s_flags
 from framework import xds_k8s_testcase

--- a/tests/gamma/affinity_session_drain_test.py
+++ b/tests/gamma/affinity_session_drain_test.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 import datetime as dt
 import logging
-from typing import Final, Optional
+from typing import Final, Optional, TypeAlias
 
 from absl import flags
 from absl.testing import absltest
-from typing_extensions import TypeAlias, override
+from typing_extensions import override
 
 from framework import xds_gamma_testcase
 from framework import xds_k8s_testcase

--- a/tests/gamma/affinity_test.py
+++ b/tests/gamma/affinity_test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import List, Optional
+from typing import List, Optional, TypeAlias
 
 from absl import flags
 from absl.testing import absltest
-from typing_extensions import TypeAlias, override
+from typing_extensions import override
 
 from framework import xds_gamma_testcase
 from framework import xds_k8s_testcase


### PR DESCRIPTION
[TypeAlias](https://docs.python.org/3/library/typing.html#typing.TypeAlias) was added in 3.10, so now we don't need to import it from `typing_extensions` anymore. 

Updating it now everywhere so that the old-style import doesn't spread by-copypasting.