### PR TITLE
Use python3.10 typing primitives

### DIFF
--- a/bin/cleanup/cleanup.py
+++ b/bin/cleanup/cleanup.py
@@ -31,7 +31,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List
 
 from absl import app
 from absl import flags

--- a/framework/bootstrap_generator_testcase.py
+++ b/framework/bootstrap_generator_testcase.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Optional
 
 from typing_extensions import override
 

--- a/framework/helpers/datetime.py
+++ b/framework/helpers/datetime.py
@@ -14,7 +14,7 @@
 """This contains common helpers for working with dates and time."""
 import datetime
 import re
-from typing import Optional, Pattern
+from typing import Pattern
 
 import dateutil.parser
 

--- a/framework/helpers/grpc.py
+++ b/framework/helpers/grpc.py
@@ -15,7 +15,6 @@
 import collections
 import dataclasses
 import functools
-from typing import Optional
 
 import grpc
 from typing_extensions import TypeAlias

--- a/framework/helpers/highlighter.py
+++ b/framework/helpers/highlighter.py
@@ -19,7 +19,6 @@ and enable colorful syntax highlighting.
 TODO(sergiitk): This can be used to output protobuf responses formatted as JSON.
 """
 import logging
-from typing import Optional
 
 from absl import flags
 import pygments

--- a/framework/helpers/retryers.py
+++ b/framework/helpers/retryers.py
@@ -22,7 +22,7 @@ We use tenacity as a general-purpose retrying library.
 """
 import datetime
 import logging
-from typing import Any, Callable, List, Optional, Tuple, Type
+from typing import Any, Callable, List, Tuple, Type
 
 import tenacity
 from tenacity import _utils as tenacity_utils

--- a/framework/helpers/skips.py
+++ b/framework/helpers/skips.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass
 import enum
 import logging
 import re
-from typing import Optional
 
 from packaging import version as pkg_version
 

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -16,7 +16,7 @@ import contextlib
 import functools
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from absl import flags
 from google.cloud import secretmanager_v1

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -15,7 +15,7 @@ import dataclasses
 import datetime
 import enum
 import logging
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
 from googleapiclient import discovery
 import googleapiclient.errors

--- a/framework/infrastructure/gcp/iam.py
+++ b/framework/infrastructure/gcp/iam.py
@@ -15,7 +15,7 @@ import dataclasses
 import datetime
 import functools
 import logging
-from typing import Any, Dict, FrozenSet, Optional
+from typing import Any, Dict, FrozenSet
 
 from framework.helpers import retryers
 from framework.infrastructure import gcp

--- a/framework/infrastructure/gcp/network_services.py
+++ b/framework/infrastructure/gcp/network_services.py
@@ -15,7 +15,7 @@
 import abc
 import dataclasses
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Tuple
 
 from google.rpc import code_pb2
 import tenacity

--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -21,7 +21,7 @@ import json
 import logging
 import pathlib
 import threading
-from typing import Any, Callable, Final, List, Optional, Tuple, Union
+from typing import Any, Callable, Final, List, Tuple, Union
 import warnings
 
 from kubernetes import client

--- a/framework/infrastructure/k8s_internal/k8s_log_collector.py
+++ b/framework/infrastructure/k8s_internal/k8s_log_collector.py
@@ -16,7 +16,7 @@ import logging
 import os
 import pathlib
 import threading
-from typing import Any, Callable, Optional, TextIO
+from typing import Any, Callable, TextIO
 
 from kubernetes import client
 from kubernetes.watch import watch

--- a/framework/infrastructure/k8s_internal/k8s_port_forwarder.py
+++ b/framework/infrastructure/k8s_internal/k8s_port_forwarder.py
@@ -15,7 +15,6 @@ import logging
 import re
 import subprocess
 import time
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -14,7 +14,7 @@
 import functools
 import logging
 import random
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, List
 
 import googleapiclient.errors
 from typing_extensions import TypeAlias

--- a/framework/rpc/grpc.py
+++ b/framework/rpc/grpc.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import logging
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from google.protobuf import json_format
 import google.protobuf.message

--- a/framework/rpc/grpc_channelz.py
+++ b/framework/rpc/grpc_channelz.py
@@ -17,7 +17,7 @@ https://github.com/grpc/grpc-proto/blob/master/grpc/channelz/v1/channelz.proto
 """
 import ipaddress
 import logging
-from typing import Iterator, Optional
+from typing import Iterator
 
 import grpc
 from grpc_channelz.v1 import channelz_pb2

--- a/framework/rpc/grpc_csds.py
+++ b/framework/rpc/grpc_csds.py
@@ -19,7 +19,7 @@ import datetime as dt
 import json
 import logging
 import re
-from typing import Any, Final, Optional, Type, cast
+from typing import Any, Final, Type, cast
 
 from google.protobuf import json_format
 from typing_extensions import TypeAlias

--- a/framework/rpc/grpc_testing.py
+++ b/framework/rpc/grpc_testing.py
@@ -18,7 +18,7 @@ https://github.com/grpc/grpc/blob/master/src/proto/grpc/testing/test.proto
 from collections.abc import Sequence
 import datetime as dt
 import logging
-from typing import Any, Final, Optional, cast
+from typing import Any, Final, cast
 
 from google.protobuf import json_format
 import grpc

--- a/framework/test_app/client_app.py
+++ b/framework/test_app/client_app.py
@@ -18,7 +18,7 @@ import datetime
 import functools
 import logging
 import time
-from typing import Iterable, List, Optional
+from typing import Iterable, List
 
 import framework.errors
 from framework.helpers import retryers

--- a/framework/test_app/runners/base_runner.py
+++ b/framework/test_app/runners/base_runner.py
@@ -19,7 +19,7 @@ from abc import abstractmethod
 import functools
 import pathlib
 import threading
-from typing import Dict, Optional
+from typing import Dict
 import urllib.parse
 
 from absl import flags

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -17,7 +17,7 @@ Run xDS Test Client on Kubernetes using Gamma
 import dataclasses
 import datetime
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from typing_extensions import override
 

--- a/framework/test_app/runners/k8s/k8s_base_runner.py
+++ b/framework/test_app/runners/k8s/k8s_base_runner.py
@@ -22,7 +22,7 @@ import datetime as dt
 import functools
 import logging
 import pathlib
-from typing import List, Optional, cast
+from typing import List, cast
 
 import absl.logging
 import mako.lookup

--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -16,7 +16,6 @@ Run xDS Test Client on Kubernetes.
 """
 import dataclasses
 import logging
-from typing import Optional
 
 from framework.infrastructure import gcp
 from framework.infrastructure import k8s

--- a/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -17,7 +17,7 @@ Run xDS Test Client on Kubernetes.
 import dataclasses
 import datetime as dt
 import logging
-from typing import List, Optional
+from typing import List
 
 from typing_extensions import override
 

--- a/framework/test_app/server_app.py
+++ b/framework/test_app/server_app.py
@@ -16,7 +16,7 @@ Provides an interface to xDS Test Server running remotely.
 """
 import functools
 import logging
-from typing import Iterator, Optional
+from typing import Iterator
 
 import framework.rpc
 from framework.rpc import grpc_channelz

--- a/framework/test_cases/base_testcase.py
+++ b/framework/test_cases/base_testcase.py
@@ -14,7 +14,7 @@
 """Base test case used for xds test suites."""
 import inspect
 import traceback
-from typing import Optional, Union
+from typing import Union
 import unittest
 
 from absl import logging

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -22,7 +22,7 @@ import re
 import signal
 import time
 from types import FrameType
-from typing import Any, Callable, Final, List, Optional, Tuple, Union
+from typing import Any, Callable, Final, List, Tuple, Union
 
 from absl import flags
 from absl.testing import absltest

--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -19,7 +19,7 @@ import datetime
 import os
 import sys
 import time
-from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+from typing import Any, Iterable, Mapping, Sequence, Tuple
 import unittest
 
 from absl import flags

--- a/tests/app_net_ssa_test.py
+++ b/tests/app_net_ssa_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import Final, List, Optional
+from typing import Final, List
 
 from absl import flags
 from absl.testing import absltest

--- a/tests/authz_test.py
+++ b/tests/authz_test.py
@@ -14,7 +14,6 @@
 
 import datetime
 import time
-from typing import Optional
 
 from absl import flags
 from absl.testing import absltest

--- a/tests/gamma/affinity_session_drain_test.py
+++ b/tests/gamma/affinity_session_drain_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import datetime as dt
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from absl import flags
 from absl.testing import absltest

--- a/tests/gamma/affinity_test.py
+++ b/tests/gamma/affinity_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from typing import List, Optional
+from typing import List
 
 from absl import flags
 from absl.testing import absltest

--- a/tests/unit/helpers/skips_test.py
+++ b/tests/unit/helpers/skips_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from absl.testing import absltest
 from absl.testing import parameterized

--- a/tests/unit/test_app/client_app_test.py
+++ b/tests/unit/test_app/client_app_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from absl.testing import absltest
 

--- a/tests/unit/test_app/server_app_test.py
+++ b/tests/unit/test_app/server_app_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 from absl.testing import absltest
 


### PR DESCRIPTION
[TypeAlias](https://docs.python.org/3/library/typing.html#typing.TypeAlias) was added in 3.10, so now we don't need to import it from `typing_extensions` anymore. 

Updating it now everywhere so that the old-style import doesn't spread by-copypasting.