### PR TITLE
Revert "Exclude remove_neg_test from Dualstack test suite"

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -185,6 +185,7 @@ psm::dualstack::get_tests() {
     "round_robin_test"
     "circuit_breaking_test"
     "outlier_detection_test"
+    "remove_neg_test"
   )
 }
 


### PR DESCRIPTION
Reverts grpc/psm-interop#133

We removed `test_remove_neg` from tests because we're seeing an issue where healthy endpoints were not present in EDS response, looks like the issue was fixed somehow, this case passed in the following manual runs:
- [x] [grpc/java/v1.67.x/branch/psm-dualstack](https://source.cloud.google.com/results/invocations/ca676ade-7488-4b1a-b968-d20c55e28a3c)
- [x] [grpc/java/master/branch/psm-dualstack](https://source.cloud.google.com/results/invocations/63b7dc55-fa18-412e-9e3a-44c97a127a19)
- [x] [grpc/core/master/linux/psm-dualstack](https://source.cloud.google.com/results/invocations/6c0b252c-9e67-4aa5-8cd8-1b3500a14a3a)

I guess it's time for us to add back this test.