### PR TITLE
unskip gamma_grpcroute test

### DIFF
--- a/tests/gamma/gamma_grpcroute_test.py
+++ b/tests/gamma/gamma_grpcroute_test.py
@@ -37,7 +37,6 @@ class GammaGrpcRouteTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
         kwargs["route_kind"] = k8s.RouteKind.GRPC
         return super().initKubernetesServerRunner(**kwargs)
 
-    @absltest.unittest.skip("Skipping test until cl/655674720 is merged")
     def test_ping_pong(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma
         #   resource creation out of self.startTestServers()


### PR DESCRIPTION
The fix has already rolledout, we need to unskip this test. 

cc: @sergiitk 