### PR TITLE
Move app-net tests from CSM to LB suite

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -84,6 +84,8 @@ psm::lb::get_tests() {
     "remove_neg_test"
     "round_robin_test"
     "circuit_breaking_test"
+    "app_net_ssa_test"
+    "app_net_csm_observability_test"
   )
   # master-only tests
   if [[ "${TESTING_VERSION}" =~ "master" ]]; then
@@ -319,8 +321,6 @@ psm::csm::get_tests() {
     "gamma.affinity_session_drain_test"
     "gamma.csm_observability_test"
     "gamma.csm_observability_with_injection_test"
-    "app_net_ssa_test"
-    "app_net_csm_observability_test"
   )
 }
 


### PR DESCRIPTION
This is a small part of public preview post-launch clean up. 

Internal: b/333124034