### PR TITLE
[fallback] Make the `get_stats` timeout configurable and default to 5m

### DIFF
--- a/framework/helpers/docker.py
+++ b/framework/helpers/docker.py
@@ -260,6 +260,7 @@ class Client(GrpcProcess):
         name: str,
         url: str,
         image: str,
+        stats_request_timeout_s: str,
     ):
         super().__init__(
             manager=manager,
@@ -278,13 +279,14 @@ class Client(GrpcProcess):
                 }
             },
         )
+        self.stats_request_timeout_s = stats_request_timeout_s
 
     def get_stats(self, num_rpcs: int):
         logger.debug("Sending %d requests", num_rpcs)
         stub = test_pb2_grpc.LoadBalancerStatsServiceStub(self.channel())
         res = stub.GetClientStats(
             messages_pb2.LoadBalancerStatsRequest(
-                num_rpcs=num_rpcs, timeout_sec=math.ceil(num_rpcs * 10)
+                num_rpcs=num_rpcs, timeout_sec=self.stats_request_timeout_s
             )
         )
         return res

--- a/tests/fallback_test.py
+++ b/tests/fallback_test.py
@@ -49,7 +49,11 @@ _STATUS_TIMEOUT_MS = flags.DEFINE_integer(
 _STATUS_POLL_INTERVAL_MS = flags.DEFINE_integer(
     "status_poll_interval_ms", 300, "Channel status poll interval (in ms)"
 )
-
+_STATS_REQUEST_TIMEOUT_S = flags.DEFINE_integer(
+    "stats_request_timeout_s",
+    300,
+    "Number of seconds the client will wait for the requested number of RPCs",
+)
 _LISTENER = "listener_0"
 
 absl.flags.adopt_module_key_flags(framework.xds_k8s_testcase)
@@ -92,6 +96,7 @@ class FallbackTest(absltest.TestCase):
             port=port or get_free_port(),
             url=f"xds:///{_LISTENER}",
             image=framework.xds_k8s_flags.CLIENT_IMAGE.value,
+            stats_request_timeout_s = _STATS_REQUEST_TIMEOUT_S.value,
         )
 
     def start_control_plane(


### PR DESCRIPTION
Go test seems to fail because timeout is too short. Making it configurable should help with the debugging. Setting it to 5m might just fix the issue.