### PR TITLE
Break up `is_supported` check into parsing and evaluating steps

### DIFF
--- a/framework/xds_url_map_testcase.py
+++ b/framework/xds_url_map_testcase.py
@@ -220,9 +220,11 @@ class XdsUrlMapTestCase(
         logging.info("----- Testing %s -----", cls.__name__)
         logging.info("Logs timezone: %s", time.localtime().tm_zone)
 
+        lang_spec = xds_k8s_testcase.parse_lang_spec_from_flags()
+
         # Raises unittest.SkipTest if given client/server/version does not
         # support current test case.
-        xds_k8s_testcase.evaluate_test_config(cls.is_supported)
+        xds_k8s_testcase.evaluate_is_supported(lang_spec, cls.is_supported)
 
         # Configure cleanup to run after all tests regardless of
         # whether setUpClass failed.


### PR DESCRIPTION
Separates `evaluate_test_config` into `parse_lang_spec_from_flags` and `evaluate_is_supported` so that custom override logic can be inserted between them.

This change exposed a bug with `cls.lang_spec.server_lang` getting out of sync with `cls.server_image` when the image is overridden in suite's `setUpClass()`.