### PR TITLE
Add Node interop server

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -445,9 +445,6 @@ psm::run::test() {
   # Some test suites have canonical server image configured in the flagfiles.
   if [[ -z "${SERVER_IMAGE_USE_CANONICAL}" ]]; then
     PSM_TEST_FLAGS+=("--server_image=${SERVER_IMAGE_NAME}:${GIT_COMMIT}")
-  elif [[ "${GRPC_LANGUAGE}" == "node"  ]]; then
-    # TODO(b/261911148): To be replaced with --server_image_use_canonical when implemented.
-    PSM_TEST_FLAGS+=("--server_image=us-docker.pkg.dev/grpc-testing/psm-interop/java-server:canonical-v1.66")
   fi
 
   # So far, only LB test uses secondary GKE cluster.
@@ -535,14 +532,9 @@ psm::setup::docker_image_names() {
   SERVER_IMAGE_USE_CANONICAL=""
 
   case "${language}" in
-    java | cpp | python | go)
+    java | cpp | python | go | node)
       CLIENT_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
       SERVER_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-server"
-      ;;
-    node)
-      CLIENT_IMAGE_NAME="${DOCKER_REGISTRY}/grpc-testing/psm-interop/${GRPC_LANGUAGE}-client"
-      SERVER_IMAGE_NAME=""
-      SERVER_IMAGE_USE_CANONICAL="1"
       ;;
     *)
       psm::tools::log "Unknown Language: ${1}"

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -236,6 +236,10 @@ class XdsKubernetesBaseTestCase(base_testcase.BaseTestCase):
         # Other
         cls.yaml_highlighter = framework.helpers.highlighter.HighlighterYaml()
 
+        # The Node server was added in version 1.13.x
+        if cls.lang_spec.client_lang == skips.Lang.NODE and not cls.lang_spec.version_gte('v1.13.x'):
+            cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value
+
     @classmethod
     def _pretty_accumulated_stats(
         cls,

--- a/tests/circuit_breaking_test.py
+++ b/tests/circuit_breaking_test.py
@@ -47,8 +47,8 @@ class CircuitBreakingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         https://github.com/grpc/grpc/blob/master/doc/xds-test-descriptions.md#server
         """
         super().setUpClass()
-        if cls.lang_spec.client_lang is not _Lang.JAVA:
-            # gRPC C++, go, python and node fallback to the gRPC Java.
+        if cls.lang_spec.client_lang is not _Lang.JAVA | _Lang.NODE:
+            # gRPC C++, go, and python fallback to the gRPC Java.
             # TODO(https://github.com/grpc/grpc-go/issues/6288): use go server.
             # TODO(https://github.com/grpc/grpc/issues/33134): use python server.
             cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value

--- a/tests/custom_lb_test.py
+++ b/tests/custom_lb_test.py
@@ -46,7 +46,8 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
 
         # gRPC Java implemented server "error-code-" rpc-behavior in v1.47.x.
         # gRPC CPP implemented rpc-behavior in the same version, as custom_lb.
-        if client_lang in _Lang.JAVA | _Lang.CPP:
+        # gRPC Node implemented the server in 1.13.x
+        if client_lang in _Lang.JAVA | _Lang.CPP | _Lang.NODE:
             return
 
         # gRPC Go implemented server "error-code-" rpc-behavior in v1.59.x,
@@ -54,7 +55,7 @@ class CustomLbTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         if client_lang == _Lang.GO and cls.lang_spec.version_gte("v1.59.x"):
             return
 
-        # gRPC go, python and node fallback to the gRPC Java.
+        # gRPC go and python fallback to the gRPC Java.
         # TODO(https://github.com/grpc/grpc/issues/33134): use python server.
         cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value
 

--- a/tests/dualstack_test.py
+++ b/tests/dualstack_test.py
@@ -57,7 +57,7 @@ class DualStackTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         # TODO: when Java 1.66 is available, make sure the canonical server is switched to it so
         #  that we have all features we need for the dualstack test
         super().setUpClass()
-        if cls.lang_spec.client_lang is not _Lang.JAVA:
+        if cls.lang_spec.client_lang not in _Lang.JAVA | _Lang.NODE:
             cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value
 
     def setUp(self):

--- a/tests/outlier_detection_test.py
+++ b/tests/outlier_detection_test.py
@@ -56,7 +56,8 @@ class OutlierDetectionTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         client_lang = cls.lang_spec.client_lang
 
         # gRPC Java implemented server "error-code-" rpc-behavior in v1.47.x.
-        if client_lang == _Lang.JAVA:
+        # gRPC Node implemented the server in v1.13.x
+        if client_lang == _Lang.JAVA | _Lang.NODE:
             return
 
         # gRPC CPP implemented server "hostname" rpc-behavior in v1.57.x,
@@ -69,7 +70,7 @@ class OutlierDetectionTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         if client_lang == _Lang.GO and cls.lang_spec.version_gte("v1.59.x"):
             return
 
-        # gRPC go, python and node fallback to the gRPC Java.
+        # gRPC go and python fallback to the gRPC Java.
         # TODO(https://github.com/grpc/grpc-go/issues/6288): use go server.
         # TODO(https://github.com/grpc/grpc/issues/33134): use python server.
         cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value


### PR DESCRIPTION
This modifies the driver to use the Node interop server implemented in https://github.com/grpc/grpc-node/pull/2897 whenever possible. Test runs:

- [ ] [grpc/node/master/xds_k8s_lb](https://source.cloud.google.com/results/invocations/5eda22ed-1bf6-4a9e-b7ee-7da93c2dfa09)
- [ ] [grpc/node/master/psm-dualstack](https://source.cloud.google.com/results/invocations/407b7ba1-ce14-4e3d-a025-b9219fffb3e1)