### PR TITLE
Allow running dualstack tests for Go

### DIFF
--- a/tests/dualstack_test.py
+++ b/tests/dualstack_test.py
@@ -49,6 +49,8 @@ class DualStackTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             return config.version_gte("v1.66.x")
         if config.client_lang == _Lang.NODE:
             return config.version_gte("v1.12.x")
+        if config.client_lang == _Lang.GO:
+            return config.version_gte("v1.71.x")
         return False
 
     @classmethod


### PR DESCRIPTION
v1.71.x is the next release, so that should be the first one that has the dualstack feature available. This change should allow running the test against master.

Local test run link (internal): http://gpaste/5061417550741504