### PR TITLE
Enable security_test for Node

### DIFF
--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -40,7 +40,7 @@ class SecurityTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
             # https://github.com/grpc/grpc/blob/master/doc/grpc_xds_features.md
             return config.version_gte("v1.41.x")
         elif config.client_lang == _Lang.NODE:
-            return False
+            return config.version_gte("v1.13.x")
         return True
 
     def test_mtls(self):


### PR DESCRIPTION
This requires the test implementation in https://github.com/grpc/grpc-node/pull/2909 to work. Test run:

- [x] [grpc/node/master/psm-security](https://source.cloud.google.com/results/invocations/369e192d-9c64-4475-b236-55ae6155410b)