### PR TITLE
Increased retry time for gamma.affinity_session_drain_test

### DIFF
--- a/tests/gamma/affinity_session_drain_test.py
+++ b/tests/gamma/affinity_session_drain_test.py
@@ -42,7 +42,7 @@ REPLICA_COUNT: Final[int] = 3
 # TODO(sergiitk): update comment
 TERMINATION_GRACE_PERIOD: Final[dt.timedelta] = dt.timedelta(minutes=10)
 DRAINING_TIMEOUT: Final[dt.timedelta] = dt.timedelta(minutes=10)
-TRAFFIC_PIN_TIMEOUT: Final[dt.timedelta] = dt.timedelta(minutes=1)
+TRAFFIC_PIN_TIMEOUT: Final[dt.timedelta] = dt.timedelta(minutes=2)
 TRAFFIC_PIN_RETRY_WAIT: Final[dt.timedelta] = dt.timedelta(seconds=5)
 
 


### PR DESCRIPTION
failing stage: 04_confirm_all_servers_receive_traffic

We are verifying all 3 server receives traffic. Channel becomes ready as soon as one of the server is connected. In this case we see all RPCs going to that. We need to give time for other instances to come up.

Increasing the retry timeout from 1 min to 2 min to reduce flakiness.


Internal: b/379040924