### PR TITLE
skipping failover test due to switch to single region sandbox

### DIFF
--- a/tests/failover_test.py
+++ b/tests/failover_test.py
@@ -33,6 +33,7 @@ _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _KubernetesServerRunner = k8s_xds_server_runner.KubernetesServerRunner
 
+
 @absltest.skip("switching to a single regional sandbox due to b/397859175")
 class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     REPLICA_COUNT = 3

--- a/tests/failover_test.py
+++ b/tests/failover_test.py
@@ -34,10 +34,15 @@ _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _KubernetesServerRunner = k8s_xds_server_runner.KubernetesServerRunner
 
 
-@absltest.skip("switching to a single regional sandbox due to b/397859175")
 class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     REPLICA_COUNT = 3
     MAX_RATE_PER_ENDPOINT = 100
+
+    @staticmethod
+    def is_supported(config: skips.TestConfig) -> bool:
+        # removing support as we're switching to a single regional
+        # sandbox due to b/397859175"
+        return False
 
     @classmethod
     def setUpClass(cls):

--- a/tests/failover_test.py
+++ b/tests/failover_test.py
@@ -33,7 +33,7 @@ _XdsTestServer = xds_k8s_testcase.XdsTestServer
 _XdsTestClient = xds_k8s_testcase.XdsTestClient
 _KubernetesServerRunner = k8s_xds_server_runner.KubernetesServerRunner
 
-
+@absltest.skip("switching to a single regional sandbox due to b/397859175")
 class FailoverTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
     REPLICA_COUNT = 3
     MAX_RATE_PER_ENDPOINT = 100


### PR DESCRIPTION
Context: We're shifting to creating a single region sandbox as recently we've been seeing repeated cluster repair operations on our multi regional sandbox, and the GKE team suggested using a single regional sandbox as a potential fix for the issue.  (Internal: b/386896489 and b/397859175)

Skipping failover test as it requires multi-region.