### PR TITLE
Updating bootstrap version in common.cfg

### DIFF
--- a/config/common.cfg
+++ b/config/common.cfg
@@ -1,5 +1,5 @@
 --resource_prefix=psm-interop
---td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:ad35743ff01c0dc16a785e421591d7d52f3cdda4
+--td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:ee0d85b47aad4b6352975505996116de838843ad
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,


### PR DESCRIPTION
Update the default bootstrap from `ad35743ff01c0dc16a785e421591d7d52f3cdda4` to `ee0d85b47aad4b6352975505996116de838843ad`.

Changes: https://github.com/GoogleCloudPlatform/traffic-director-grpc-bootstrap/compare/ad35743...ee0d85b 