### PR TITLE
GcpStandardCloudApiResource: handle non-standard operation "done"

### DIFF
--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -594,10 +594,14 @@ class GcpStandardCloudApiResource(GcpProjectApiResource, metaclass=abc.ABCMeta):
         )
         operation = self.wait_for_operation(
             operation_request=op_request,
-            test_success_fn=lambda result: result["done"],
+            test_success_fn=self._operation_status_done,
             timeout_sec=timeout_sec,
         )
 
         logger.debug("Completed operation: %s", operation)
         if "error" in operation:
             raise OperationError(self.api_name, operation)
+
+    @staticmethod
+    def _operation_status_done(result) -> bool:
+        return "done" in result and result["done"]

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -603,5 +603,5 @@ class GcpStandardCloudApiResource(GcpProjectApiResource, metaclass=abc.ABCMeta):
             raise OperationError(self.api_name, operation)
 
     @staticmethod
-    def _operation_status_done(result: dict[str, Any]) -> bool:
-        return result.get("done")
+    def _operation_status_done(operation: dict[str, Any]) -> bool:
+        return operation.get("done")

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -603,5 +603,5 @@ class GcpStandardCloudApiResource(GcpProjectApiResource, metaclass=abc.ABCMeta):
             raise OperationError(self.api_name, operation)
 
     @staticmethod
-    def _operation_status_done(result) -> bool:
-        return "done" in result and result["done"]
+    def _operation_status_done(result: dict[str, Any]) -> bool:
+        return result.get("done")


### PR DESCRIPTION
Handles operation responses that instead of setting `done: false` don't set the `done` field at all until the op is completed. 
Also allows to override the callback that determines if the op is done on per-API level.

Needed for CloudRun API: #154