### PR TITLE
(minor) Fix return type hints in GcpStandardCloudApiResource create_*

### DIFF
--- a/framework/infrastructure/gcp/network_security.py
+++ b/framework/infrastructure/gcp/network_security.py
@@ -24,9 +24,6 @@ from framework.infrastructure import gcp
 
 logger = logging.getLogger(__name__)
 
-# Type aliases
-GcpResource = gcp.compute.ComputeV1.GcpResource
-
 
 @dataclasses.dataclass(frozen=True)
 class ServerTlsPolicy:
@@ -147,8 +144,8 @@ class NetworkSecurityV1Beta1(_NetworkSecurityBase):
     def api_version(self) -> str:
         return "v1beta1"
 
-    def create_server_tls_policy(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_server_tls_policy(self, name: str, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.serverTlsPolicies(),
             body=body,
             serverTlsPolicyId=name,
@@ -167,8 +164,8 @@ class NetworkSecurityV1Beta1(_NetworkSecurityBase):
             full_name=self.resource_full_name(name, self.SERVER_TLS_POLICIES),
         )
 
-    def create_client_tls_policy(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_client_tls_policy(self, name: str, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.clientTlsPolicies(),
             body=body,
             clientTlsPolicyId=name,
@@ -187,8 +184,8 @@ class NetworkSecurityV1Beta1(_NetworkSecurityBase):
             full_name=self.resource_full_name(name, self.CLIENT_TLS_POLICIES),
         )
 
-    def create_authz_policy(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_authz_policy(self, name: str, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.authorizationPolicies(),
             body=body,
             authorizationPolicyId=name,

--- a/framework/infrastructure/gcp/network_services.py
+++ b/framework/infrastructure/gcp/network_services.py
@@ -169,9 +169,7 @@ class GrpcRoute:
     meshes: Optional[Tuple[str]]
 
     @classmethod
-    def from_response(
-        cls, name: str, d: Dict[str, Any]
-    ) -> "GrpcRoute.RouteRule":
+    def from_response(cls, name: str, d: dict[str, Any]) -> "GrpcRoute":
         return cls(
             name=name,
             url=d["name"],
@@ -454,7 +452,7 @@ class NetworkServicesV1(_NetworkServicesBase):
         )
         return GrpcRoute.from_response(name, result)
 
-    def get_http_route(self, name: str) -> GrpcRoute:
+    def get_http_route(self, name: str) -> HttpRoute:
         full_name = self.resource_full_name(name, self.HTTP_ROUTES)
         result = self._get_resource(
             collection=self._api_locations.httpRoutes(), full_name=full_name

--- a/framework/infrastructure/gcp/network_services.py
+++ b/framework/infrastructure/gcp/network_services.py
@@ -24,9 +24,6 @@ from framework.infrastructure import gcp
 
 logger = logging.getLogger(__name__)
 
-# Type aliases
-GcpResource = gcp.compute.ComputeV1.GcpResource
-
 
 @dataclasses.dataclass(frozen=True)
 class EndpointPolicy:
@@ -365,8 +362,8 @@ class NetworkServicesV1Beta1(_NetworkServicesBase):
     def api_version(self) -> str:
         return "v1beta1"
 
-    def create_endpoint_policy(self, name, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_endpoint_policy(self, name, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.endpointPolicies(),
             body=body,
             endpointPolicyId=name,
@@ -398,8 +395,8 @@ class NetworkServicesV1(_NetworkServicesBase):
     def api_version(self) -> str:
         return "v1"
 
-    def create_endpoint_policy(self, name, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_endpoint_policy(self, name, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.endpointPolicies(),
             body=body,
             endpointPolicyId=name,
@@ -418,8 +415,8 @@ class NetworkServicesV1(_NetworkServicesBase):
             full_name=self.resource_full_name(name, self.ENDPOINT_POLICIES),
         )
 
-    def create_mesh(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_mesh(self, name: str, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.meshes(), body=body, meshId=name
         )
 
@@ -436,15 +433,15 @@ class NetworkServicesV1(_NetworkServicesBase):
             full_name=self.resource_full_name(name, self.MESHES),
         )
 
-    def create_grpc_route(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_grpc_route(self, name: str, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.grpcRoutes(),
             body=body,
             grpcRouteId=name,
         )
 
-    def create_http_route(self, name: str, body: dict) -> GcpResource:
-        return self._create_resource(
+    def create_http_route(self, name: str, body: dict) -> None:
+        self._create_resource(
             collection=self._api_locations.httpRoutes(),
             body=body,
             httpRouteId=name,

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -942,14 +942,14 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
         self.http_route: Optional[HttpRoute] = None
         self.mesh: Optional[Mesh] = None
 
-    def create_mesh(self) -> GcpResource:
+    def create_mesh(self) -> Mesh:
         name = self.make_resource_name(self.MESH_NAME)
         logger.info("Creating Mesh %s", name)
         body = {}
-        resource = self.netsvc.create_mesh(name, body)
+        self.netsvc.create_mesh(name, body)
         self.mesh = self.netsvc.get_mesh(name)
         logger.debug("Loaded Mesh: %s", self.mesh)
-        return resource
+        return self.mesh
 
     def delete_mesh(self, force=False):
         if force:
@@ -962,7 +962,7 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
         self.netsvc.delete_mesh(name)
         self.mesh = None
 
-    def create_grpc_route(self, src_host: str, src_port: int) -> GcpResource:
+    def create_grpc_route(self, src_host: str, src_port: int) -> GrpcRoute:
         host = f"{src_host}:{src_port}"
         service_name = self.netsvc.resource_full_name(
             self.backend_service.name, "backendServices"
@@ -976,26 +976,26 @@ class TrafficDirectorAppNetManager(TrafficDirectorManager):
         }
         name = self.make_resource_name(self.GRPC_ROUTE_NAME)
         logger.info("Creating GrpcRoute %s", name)
-        resource = self.netsvc.create_grpc_route(name, body)
+        self.netsvc.create_grpc_route(name, body)
         self.grpc_route = self.netsvc.get_grpc_route(name)
         logger.debug("Loaded GrpcRoute: %s", self.grpc_route)
-        return resource
+        return self.grpc_route
 
-    def create_grpc_route_with_content(self, body: Any) -> GcpResource:
+    def create_grpc_route_with_content(self, body: Any) -> GrpcRoute:
         name = self.make_resource_name(self.GRPC_ROUTE_NAME)
         logger.info("Creating GrpcRoute %s", name)
-        resource = self.netsvc.create_grpc_route(name, body)
+        self.netsvc.create_grpc_route(name, body)
         self.grpc_route = self.netsvc.get_grpc_route(name)
         logger.debug("Loaded GrpcRoute: %s", self.grpc_route)
-        return resource
+        return self.grpc_route
 
-    def create_http_route_with_content(self, body: Any) -> GcpResource:
+    def create_http_route_with_content(self, body: Any) -> HttpRoute:
         name = self.make_resource_name(self.HTTP_ROUTE_NAME)
         logger.info("Creating HttpRoute %s", name)
-        resource = self.netsvc.create_http_route(name, body)
+        self.netsvc.create_http_route(name, body)
         self.http_route = self.netsvc.get_http_route(name)
         logger.debug("Loaded HttpRoute: %s", self.http_route)
-        return resource
+        return self.http_route
 
     def delete_grpc_route(self, force=False):
         if force:


### PR DESCRIPTION
GcpStandardCloudApiResource._create_resource doesn't return anything, so methods returning from it had incorrect return type.

Fixing `GcpStandardCloudApiResource._create_resource` return types unraveled a few other errors, notably incorrect return types in `TrafficDirectorAppNetManager`, `GrpcRoute. from_response` and `get_http_route`.