### PR TITLE
Remove multiple GRPC_*_EXPERIMENTAL_* env variables

### DIFF
--- a/kubernetes-manifests/client-secure.deployment.yaml
+++ b/kubernetes-manifests/client-secure.deployment.yaml
@@ -47,12 +47,6 @@ spec:
           env:
             - name: GRPC_XDS_BOOTSTRAP
               value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-            - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-              value: "true"
-            - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
-              value: "true"
-            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-              value: "true"
           volumeMounts:
             - mountPath: /tmp/grpc-xds/
               name: grpc-td-conf

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -58,14 +58,6 @@ spec:
               value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
             - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RING_HASH
               value: "true"
-            - name: GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY
-              value: "true"
-            - name: GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION
-              value: "true"
-            - name: GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG
-              value: "true"
-            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-              value: "true"
             % if enable_dualstack:
             - name: GRPC_EXPERIMENTAL_ENABLE_NEW_PICK_FIRST
               value: "true"

--- a/kubernetes-manifests/server-secure.deployment.yaml
+++ b/kubernetes-manifests/server-secure.deployment.yaml
@@ -45,17 +45,6 @@ spec:
           env:
             - name: GRPC_XDS_BOOTSTRAP
               value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-            - name: GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
-              value: "true"
-            - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
-              value: "true"
-            ## TODO(sergiitk): this should be conditional for if version < v1.37.x
-            - name: GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API
-              value: "true"
-            - name: GRPC_XDS_EXPERIMENTAL_RBAC
-              value: "true"
-            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-              value: "true"
           volumeMounts:
             - mountPath: /tmp/grpc-xds/
               name: grpc-td-conf

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -56,10 +56,6 @@ spec:
           env:
             - name: GRPC_XDS_BOOTSTRAP
               value: "/tmp/grpc-xds/td-grpc-bootstrap.json"
-            - name: GRPC_XDS_EXPERIMENTAL_V3_SUPPORT
-              value: "true"
-            - name: GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
-              value: "true"
             % if csm_workload_name:
             - name: CSM_WORKLOAD_NAME
               value: ${csm_workload_name}


### PR DESCRIPTION
These variables were set to "true", now being removed:

- GRPC_EXPERIMENTAL_ENABLE_OUTLIER_DETECTION
- GRPC_EXPERIMENTAL_XDS_CUSTOM_LB_CONFIG
- GRPC_EXPERIMENTAL_XDS_ENABLE_OVERRIDE_HOST
- GRPC_XDS_EXPERIMENTAL_ENABLE_RETRY
- GRPC_XDS_EXPERIMENTAL_NEW_SERVER_API
- GRPC_XDS_EXPERIMENTAL_RBAC
- GRPC_XDS_EXPERIMENTAL_SECURITY_SUPPORT
- GRPC_XDS_EXPERIMENTAL_V3_SUPPORT