### PR TITLE
Dualstack test: fix the order of server namespace cleanup.

### DIFF
--- a/tests/dualstack_test.py
+++ b/tests/dualstack_test.py
@@ -105,17 +105,17 @@ class DualStackTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         self.client_runner.cleanup(
             force=self.force_cleanup, force_namespace=self.force_cleanup
         )
-        self.server_runner.cleanup(
-            force=self.force_cleanup, force_namespace=False
-        )
+
+        # Don't set force_namespace: all runners share the same namespace.
         if self.v4_server_runner:
-            self.v4_server_runner.cleanup(
-                force=self.force_cleanup, force_namespace=False
-            )
+            self.v4_server_runner.cleanup(force=self.force_cleanup)
         if self.v6_server_runner:
-            self.v6_server_runner.cleanup(
-                force=self.force_cleanup, force_namespace=True
-            )
+            self.v6_server_runner.cleanup(force=self.force_cleanup)
+
+        # Pass force_namespace at the last step.
+        self.server_runner.cleanup(
+            force=self.force_cleanup, force_namespace=self.force_cleanup
+        )
 
     def test_dualstack(self) -> None:
         self.assertTrue(


### PR DESCRIPTION
Previously, `force_namespace=True` was passed to `self.v6_server_runner.cleanup()`, but the the call to this method is conditional on `if self.v6_server_runner:`. 

Therefore, when `self.v6_server_runner` isn't set, there won't be anything to call forced namespace cleanup. In practice, I don't see this happening as the code is right now, but still fixing the code for future-proofing (f.e. bad refactoring or copy-pasting to a different code flow).