### PR TITLE
Enable Authz tests for Node.js

### DIFF
--- a/tests/authz_test.py
+++ b/tests/authz_test.py
@@ -56,7 +56,7 @@ class AuthzTest(xds_k8s_testcase.SecurityXdsKubernetesTestCase):
         elif config.client_lang in _Lang.GO | _Lang.JAVA:
             return config.version_gte("v1.42.x")
         elif config.client_lang == _Lang.NODE:
-            return False
+            return config.version_gte("v1.14.x")
         return True
 
     def setUp(self):


### PR DESCRIPTION
Passing interop test job:

- [x] [grpc/node/master/psm-security](https://source.cloud.google.com/results/invocations/d9b24868-fa05-437f-b4a6-cedd5c309bd8)

This depends on https://github.com/grpc/grpc-node/pull/2945.