### PR TITLE
client_app: add logger for channel

### DIFF
--- a/framework/test_app/client_app.py
+++ b/framework/test_app/client_app.py
@@ -439,6 +439,11 @@ class XdsTestClient(framework.rpc.grpc.GrpcApp):
         for channel in self.channelz.find_channels_for_target(
             self.server_target, **kwargs
         ):
+            logger.info(
+                "[%s] xDS control plane channel: %s",
+                self.hostname,
+                _ChannelzServiceClient.channel_repr(channel),
+            )
             for subchannel in self.channelz.list_channel_subchannels(
                 channel, **kwargs
             ):

--- a/tests/cloud_run_csm_inbound_test.py
+++ b/tests/cloud_run_csm_inbound_test.py
@@ -38,6 +38,10 @@ class CloudRunCsmInboundTest(cloud_run_testcase.CloudRunXdsKubernetesTestCase):
     @override
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang is _Lang.CPP:
+            return config.version_gte("v1.69.x")
+        elif config.client_lang is _Lang.PYTHON:
+            return config.version_gte("v1.69.x")
+        elif config.client_lang is _Lang.JAVA:
             return config.version_gte("v1.71.x")
         return False
 


### PR DESCRIPTION
Adding logger to print channel information to debug dualstack affinity test failing with error `The client expected to have one READY subchannel to one of the test servers. Found 2 instead.`

[b/374693206](https://b.corp.google.com/issues/374693206)