### PR TITLE
[CloudRun to CloudRun]: Parse stats_port arg from --client_port

### DIFF
--- a/framework/test_app/runners/cloud_run/cloud_run_xds_client_runner.py
+++ b/framework/test_app/runners/cloud_run/cloud_run_xds_client_runner.py
@@ -25,7 +25,6 @@ from framework.test_app.runners.cloud_run import cloud_run_base_runner
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CLIENT_TEST_PORT: Final[int] = 50052  # This is the stats service port.
 DEFAULT_PORT: Final[int] = 443
 
 
@@ -34,6 +33,7 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
 
     mesh_name: str
     server_target: str
+    stats_port: int
 
     service: Optional[gcp.cloud_run.CloudRunService] = None
     current_revision: Optional[str] = None
@@ -46,6 +46,7 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
         network: str,
         region: str,
         gcp_api_manager: gcp.api.GcpApiManager,
+        stats_port: int = 8079,
     ):
         super().__init__(
             project,
@@ -55,6 +56,7 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
             region=region,
             gcp_api_manager=gcp_api_manager,
         )
+        self.stats_port = stats_port
 
         self._initalize_cloud_run()
 
@@ -88,6 +90,7 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
             image_name=self.image_name,
             mesh_name=mesh_name,
             server_target=server_target,
+            stats_port=self.stats_port,
         )
         self.current_revision = self.service.revision
         client = self._make_client_from_service(server_target, self.service)
@@ -126,7 +129,7 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
         mesh_name: str,
         server_target: str,
         *,
-        test_port: int = DEFAULT_CLIENT_TEST_PORT,
+        stats_port: int,
     ) -> gcp.cloud_run.CloudRunService:
         if not service_name:
             raise ValueError("service_name cannot be empty or None")
@@ -141,13 +144,14 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
                         "image": image_name,
                         "ports": [
                             {
-                                "containerPort": test_port,
+                                "containerPort": stats_port,
                                 "name": "h2c",
                             }
                         ],
                         "args": [
                             f"--server={server_target}",
                             "--secure_mode=true",
+                            f"--stats_port={stats_port}",
                         ],
                         "env": [
                             {

--- a/framework/test_app/runners/cloud_run/cloud_run_xds_client_runner.py
+++ b/framework/test_app/runners/cloud_run/cloud_run_xds_client_runner.py
@@ -124,11 +124,11 @@ class CloudRunClientRunner(cloud_run_base_runner.CloudRunBaseRunner):
 
     def deploy_service(
         self,
+        *,
         service_name: str,
         image_name: str,
         mesh_name: str,
         server_target: str,
-        *,
         stats_port: int,
     ) -> gcp.cloud_run.CloudRunService:
         if not service_name:

--- a/framework/test_cases/cloud_run_testcase.py
+++ b/framework/test_cases/cloud_run_testcase.py
@@ -14,7 +14,7 @@
 import datetime as dt
 import logging
 
-from typing_extensions import override
+from typing_extensions import override, TypeAlias
 
 from framework import xds_flags
 from framework import xds_k8s_testcase
@@ -171,6 +171,7 @@ class CloudRunXdsTestCase(CloudRunXdsKubernetesTestCase):
             network=self.network,
             region=self.region,
             gcp_api_manager=self.gcp_api_manager,
+            stats_port=self.client_port,
         )
         test_client = self.client_runner.run(
             server_target=test_server.xds_uri,

--- a/framework/test_cases/cloud_run_testcase.py
+++ b/framework/test_cases/cloud_run_testcase.py
@@ -14,7 +14,7 @@
 import datetime as dt
 import logging
 
-from typing_extensions import TypeAlias, override
+from typing_extensions import override
 
 from framework import xds_flags
 from framework import xds_k8s_testcase

--- a/framework/test_cases/cloud_run_testcase.py
+++ b/framework/test_cases/cloud_run_testcase.py
@@ -14,7 +14,7 @@
 import datetime as dt
 import logging
 
-from typing_extensions import override, TypeAlias
+from typing_extensions import TypeAlias, override
 
 from framework import xds_flags
 from framework import xds_k8s_testcase

--- a/tests/cloud_run_csm_inbound_test.py
+++ b/tests/cloud_run_csm_inbound_test.py
@@ -38,6 +38,10 @@ class CloudRunCsmInboundTest(cloud_run_testcase.CloudRunXdsKubernetesTestCase):
     @override
     def is_supported(config: skips.TestConfig) -> bool:
         if config.client_lang is _Lang.CPP:
+            return config.version_gte("v1.69.x")
+        elif config.client_lang is _Lang.PYTHON:
+            return config.version_gte("v1.69.x")
+        elif config.client_lang is _Lang.JAVA:
             return config.version_gte("v1.71.x")
         return False
 

--- a/tests/cloud_run_csm_outbound_test.py
+++ b/tests/cloud_run_csm_outbound_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import datetime as dt
 import logging
 from typing import TypeAlias
 


### PR DESCRIPTION
Parse stats_port arg from --client_port to make sure the correct container port is used in Cloud run client for every language client.