### PR TITLE
cleanup: fixes gamma cleanup

### DIFF
--- a/bin/cleanup/cleanup.py
+++ b/bin/cleanup/cleanup.py
@@ -453,6 +453,7 @@ def cleanup_gamma_server(
     gcp_service_account,
     *,
     suffix: Optional[str] = "",
+    enable_dualstack: bool = False,
 ):
     deployment_name = xds_flags.SERVER_NAME.value
     if suffix:


### PR DESCRIPTION
The CSM cleanup script has been failing for some time with an error:

>  1. Unexpected error while deleting namespace psm-csm-server-20250715-1258-2ujy4: cleanup_gamma_server() got an unexpected keyword argument 'enable_dualstack'

[Failure run](http://sponge2/139da22a-83e8-4e92-9b85-098a5cd0b53b).
[Run with this fix](http://sponge2/bba8cc1f-fb66-4253-82f5-41654ae5f905)