### PR TITLE
Update CODEOWNERS - rename the admin group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @grpc/grpc-psm-interop
+* @grpc/grpc-psm-interop-admin


### PR DESCRIPTION
`@grpc/grpc-psm-interop` renamed to `@grpc/grpc-psm-interop-admin` to follow the we use for other repos.