### PR TITLE
Avoid NoneType error for missing annotation list in Gamma route resource

### DIFF
--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -609,8 +609,12 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         kind: RouteKind,
     ) -> bool:
         route = self._get_dyn_resource(self.gamma_route_apis[kind], name)
-        return route.metadata.annotations is not None \
+        print("Route metadata:", flush=True)
+        print(route.metadata, flush=True)
+        return (
+            route.metadata.annotations is not None
             and self.MESH_ANNOTATION in route.metadata.annotations
+        )
 
     def get_session_affinity_policy(
         self, name

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -238,7 +238,7 @@ class GammaServerRunner(KubernetesServerRunner):
         self.k8s_namespace.wait_for_mesh_annotation_on_gamma_route(
             name=self.route_name,
             kind=k8s.RouteKind.HTTP,
-            timeout_sec=datetime.timedelta(minutes=40).total_seconds(),
+            timeout_sec=datetime.timedelta(minutes=1).total_seconds(),
         )
         return servers
 


### PR DESCRIPTION
Avoid type error when no annotation is present, and increase wait time to 40 min because the meshes annotation is still not available after 20 minutes.

Follow up to PR #193. 