### PR TITLE
Revert "Add retries for expected control plane statuses and rpcs"

### DIFF
--- a/tests/fallback_test.py
+++ b/tests/fallback_test.py
@@ -173,8 +173,8 @@ class FallbackTest(absltest.TestCase):
             self.start_server(name="server2") as server2,
             self.start_client() as client,
         ):
-            self.check_ads_connections_statuses(
-                client,
+            self.assert_ads_connections(
+                client=client,
                 primary_status=channelz_pb2.ChannelConnectivityState.TRANSIENT_FAILURE,
                 fallback_status=channelz_pb2.ChannelConnectivityState.TRANSIENT_FAILURE,
             )
@@ -216,21 +216,25 @@ class FallbackTest(absltest.TestCase):
                         and "server1" in stats.rpcs_by_peer
                         and stats.rpcs_by_peer["server1"] > 0,
                     )
-                retryer(client.get_stats, 10)
-                self.check_ads_connections_statuses(
-                    client,
+                    retryer(client.get_stats, 10)
+                self.assert_ads_connections(
+                    client=client,
                     primary_status=channelz_pb2.ChannelConnectivityState.TRANSIENT_FAILURE,
                     fallback_status=None,
                 )
                 # Primary control plane down, cached value is used
-                self.wait_for_given_server_to_receive_rpcs(client, "server1")
-            self.check_ads_connections_statuses(
-                client,
+                stats = client.get_stats(5)
+                self.assertEqual(stats.num_failures, 0)
+                self.assertEqual(stats.rpcs_by_peer["server1"], 5)
+            self.assert_ads_connections(
+                client=client,
                 primary_status=channelz_pb2.ChannelConnectivityState.TRANSIENT_FAILURE,
                 fallback_status=None,
             )
             # Fallback control plane down, cached value is used
-            self.wait_for_given_server_to_receive_rpcs(client, "server1")
+            stats = client.get_stats(5)
+            self.assertEqual(stats.num_failures, 0)
+            self.assertEqual(stats.rpcs_by_peer["server1"], 5)
 
     def test_fallback_mid_startup(self):
         # Run the mesh, excluding the client
@@ -255,27 +259,31 @@ class FallbackTest(absltest.TestCase):
             )
             # Run client
             with self.start_client() as client:
-                self.check_ads_connections_statuses(
+                self.assert_ads_connections(
                     client,
                     primary_status=channelz_pb2.ChannelConnectivityState.TRANSIENT_FAILURE,
                     fallback_status=channelz_pb2.ChannelConnectivityState.READY,
                 )
                 # Secondary xDS config start, send traffic to server2
-                self.wait_for_given_server_to_receive_rpcs(client, "server2")
+                stats = client.get_stats(5)
+                self.assertEqual(stats.num_failures, 0)
+                self.assertGreater(stats.rpcs_by_peer["server2"], 0)
+                self.assertNotIn("server1", stats.rpcs_by_peer)
                 # Rerun primary control plane
                 with self.start_control_plane(
                     "primary_xds_config_run_2",
                     port=self.bootstrap.primary_port,
                     upstream_port=server1.port,
                 ):
-                    self.check_ads_connections_statuses(
+                    self.assert_ads_connections(
                         client,
                         primary_status=channelz_pb2.ChannelConnectivityState.READY,
                         fallback_status=None,
                     )
-                    self.wait_for_given_server_to_receive_rpcs(
-                        client, "server1"
-                    )
+                    stats = client.get_stats(10)
+                    self.assertEqual(stats.num_failures, 0)
+                    self.assertIn("server1", stats.rpcs_by_peer)
+                    self.assertGreater(stats.rpcs_by_peer["server1"], 0)
 
     def test_fallback_mid_update(self):
         with (
@@ -300,7 +308,8 @@ class FallbackTest(absltest.TestCase):
                 fallback_status=None,
             )
             # Secondary xDS config start, send traffic to server2
-            self.wait_for_given_server_to_receive_rpcs(client, "server1")
+            stats = client.get_stats(5)
+            self.assertGreater(stats.rpcs_by_peer["server1"], 0)
             primary.stop_on_resource_request(
                 "type.googleapis.com/envoy.config.cluster.v3.Cluster",
                 "test_cluster_2",
@@ -318,7 +327,13 @@ class FallbackTest(absltest.TestCase):
                 primary_status=channelz_pb2.ChannelConnectivityState.TRANSIENT_FAILURE,
                 fallback_status=channelz_pb2.ChannelConnectivityState.READY,
             )
-            self.wait_for_given_server_to_receive_rpcs(client, "server2")
+            retryer = retryers.constant_retryer(
+                wait_fixed=datetime.timedelta(seconds=1),
+                timeout=datetime.timedelta(seconds=20),
+                check_result=lambda stats: stats.num_failures == 0
+                and "server2" in stats.rpcs_by_peer,
+            )
+            retryer(client.get_stats, 10)
             # Check that post-recovery uses a new config
             with self.start_control_plane(
                 name="primary_xds_config_run_2",
@@ -337,16 +352,6 @@ class FallbackTest(absltest.TestCase):
                     and "server3" in stats.rpcs_by_peer,
                 )
                 retryer(client.get_stats, 10)
-
-    def wait_for_given_server_to_receive_rpcs(self, client, server_name):
-        retryer = retryers.constant_retryer(
-            wait_fixed=datetime.timedelta(seconds=1),
-            timeout=datetime.timedelta(seconds=20),
-            check_result=lambda stats: stats.num_failures == 0
-            and server_name in stats.rpcs_by_peer
-            and len(stats) == 1,
-        )
-        retryer(client.get_stats, 10)
 
     def check_ads_connections_statuses(
         self, client, primary_status, fallback_status


### PR DESCRIPTION
Reverts grpc/psm-interop#196

#196 broke the test with the following error:

```pytb
W0827 15:22:19.017910 128386596818944 retryers.py:175] Result check callback __main__.FallbackTest.wait_for_given_server_to_receive_rpcs.<locals>.<lambda> raised an exception.This shouldn't happen, please handle any exceptions and return return a boolean.
Traceback (most recent call last):
  File "framework/helpers/retryers.py", line 173, in _check_result_wrapped
    return check_result(result)
  File "tests/fallback_test.py", line 347, in <lambda>
    and len(stats) == 1,
TypeError: object of type 'LoadBalancerStatsResponse' has no len()


I0827 15:22:19.748453 128386497762880 docker.py:173] [server2] Shutting down
I0827 15:22:20.263980 128386506155584 docker.py:173] [server1] Shutting down
[  FAILED  ] FallbackTest.test_fallback_on_startup
======================================================================
ERROR: test_fallback_mid_startup (__main__.FallbackTest)
FallbackTest.test_fallback_mid_startup
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/fallback_test.py", line 264, in test_fallback_mid_startup
    self.wait_for_given_server_to_receive_rpcs(client, "server2")
  File "tests/fallback_test.py", line 349, in wait_for_given_server_to_receive_rpcs
    retryer(client.get_stats, 10)
  File "venv/lib/python3.10/site-packages/tenacity/__init__.py", line 423, in __call__
    do = self.iter(retry_state=retry_state)
  File "venv/lib/python3.10/site-packages/tenacity/__init__.py", line 369, in iter
    return self.retry_error_callback(retry_state=retry_state)
  File "framework/helpers/retryers.py", line 147, in error_handler
    raise RetryError(
framework.helpers.retryers.RetryError: Retry error calling framework.helpers.docker.Client.get_stats: timeout 0:00:20 (h:mm:ss) exceeded. Check result callback returned False.

...
```

Example: https://source.cloud.google.com/results/invocations/fa008626-dfe2-4a86-87a6-afd3d76b9ed9

Potentially the change was incompatible with the updated grpcio packages (#197), or just not tested properly.

