### PR TITLE
Handle missing annotations and reduce mesh annotation timeout 

### DIFF
--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -838,8 +838,8 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         retryer = retryers.constant_retryer(
             wait_fixed=_timedelta(seconds=wait_sec),
             timeout=timeout,
-            check_result=lambda resource: resource.metadata.annotations
-            is not None
+            check_result=lambda resource: resource.metadata is not None
+            and resource.metadata.annotations is not None
             and self.MESH_ANNOTATION in resource.metadata.annotations,
         )
         try:

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -238,7 +238,7 @@ class GammaServerRunner(KubernetesServerRunner):
         self.k8s_namespace.wait_for_mesh_annotation_on_gamma_route(
             name=self.route_name,
             kind=k8s.RouteKind.HTTP,
-            timeout_sec=datetime.timedelta(minutes=20).total_seconds(),
+            timeout_sec=datetime.timedelta(minutes=1).total_seconds(),
         )
         return servers
 

--- a/framework/test_app/runners/k8s/gamma_server_runner.py
+++ b/framework/test_app/runners/k8s/gamma_server_runner.py
@@ -238,7 +238,7 @@ class GammaServerRunner(KubernetesServerRunner):
         self.k8s_namespace.wait_for_mesh_annotation_on_gamma_route(
             name=self.route_name,
             kind=k8s.RouteKind.HTTP,
-            timeout_sec=datetime.timedelta(minutes=50).total_seconds(),
+            timeout_sec=datetime.timedelta(minutes=20).total_seconds(),
         )
         return servers
 


### PR DESCRIPTION
Handle missing annotations and reduce timeout waiting for mesh annotation from 50 min to 20 min.