### PR TITLE
Restructure remove_neg_test

### DIFF
--- a/tests/remove_neg_test.py
+++ b/tests/remove_neg_test.py
@@ -101,10 +101,13 @@ class RemoveNegTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             self.assertRpcsEventuallyGoToGivenServers(
                 test_client, default_test_servers
             )
-            # Bring up backend for next step
-            self.setupServerBackends(server_runner=self.alternate_server_runner)
 
         with self.subTest("11_remove_neg_main"):
+            # Bring up alternate backend and remove the main one
+            # This extra step is done so we verify both backends were running fine.
+            # This is replacing a check before step 10 where we were asserting RPC reach both server,
+            # that fails sometime as both servers might end up in diffrent priority.
+            self.setupServerBackends(server_runner=self.alternate_server_runner)
             self.removeServerBackends()
             self.assertRpcsEventuallyGoToGivenServers(
                 test_client, same_zone_test_servers

--- a/tests/remove_neg_test.py
+++ b/tests/remove_neg_test.py
@@ -109,7 +109,7 @@ class RemoveNegTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             self.assertRpcsEventuallyGoToGivenServers(
                 test_client, same_zone_test_servers
             )
- 
+
 
 if __name__ == "__main__":
     absltest.main(failfast=True)

--- a/tests/remove_neg_test.py
+++ b/tests/remove_neg_test.py
@@ -94,17 +94,22 @@ class RemoveNegTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         with self.subTest("09_test_server_received_rpcs_from_test_client"):
             self.assertSuccessfulRpcs(test_client)
 
-        with self.subTest("10_remove_neg"):
-            self.assertRpcsEventuallyGoToGivenServers(
-                test_client, default_test_servers + same_zone_test_servers
-            )
+        with self.subTest("10_remove_neg_alternate"):
             self.removeServerBackends(
                 server_runner=self.alternate_server_runner
             )
             self.assertRpcsEventuallyGoToGivenServers(
                 test_client, default_test_servers
             )
+            # Bring up backend for next step
+            self.setupServerBackends(server_runner=self.alternate_server_runner)
 
+        with self.subTest("11_remove_neg_main"):
+            self.removeServerBackends()
+            self.assertRpcsEventuallyGoToGivenServers(
+                test_client, same_zone_test_servers
+            )
+ 
 
 if __name__ == "__main__":
     absltest.main(failfast=True)

--- a/tests/remove_neg_test.py
+++ b/tests/remove_neg_test.py
@@ -105,8 +105,8 @@ class RemoveNegTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
         with self.subTest("11_remove_neg_main"):
             # Bring up alternate backend and remove the main one
             # This extra step is done so we verify both backends were running fine.
-            # This is replacing a check before step 10 where we were asserting RPC reach both server,
-            # that fails sometime as both servers might end up in diffrent priority.
+            # Note: We do it this way instead of asserting that RPCs reach both server (before step 10)
+            # Because that fails sometime as both servers might end up in diffrent priorities.
             self.setupServerBackends(server_runner=self.alternate_server_runner)
             self.removeServerBackends()
             self.assertRpcsEventuallyGoToGivenServers(


### PR DESCRIPTION
Failure : "assertRpcsEventuallyGoToGivenServers" was failing as sometime both the servers wind up in different priority causing the failures.
b/437342217

Fix: Restructure the test so we don't need to verify this .

Earlier flow:
1. Check if RPC are sent to S, S-alt
2. Remove neg for S-alt
3. Verify RPC are sent to S.

(We need step 1 as we want to check if RPC go to S-alt)

Changed Flow
1. Remove neg for S-alt
2.  Verify RPC are sent to S
3. Bring back neg for S-alt
4. Remove neg for S
5. Verify RPC are sent to S-alt

If we check both neg removal, we don't need to check RPC going to both S, S-alt 
prod:
Passed Run: [grpc/core/v1.71.x/branch/linux/psm-dualstack](https://source.cloud.google.com/results/invocations/8443a0a7-9964-4fb3-8de1-9b280c1140c4)