### PR TITLE
Revert "Update TD bootstrap image (#247)"

### DIFF
--- a/config/common.cfg
+++ b/config/common.cfg
@@ -1,5 +1,5 @@
 --resource_prefix=psm-interop
---td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:11a44a44145ad7b7c499ce669c535b4a519ff2b7
+--td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:a756beb5f56c84555095aa3622bdddd843fef95a
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,


### PR DESCRIPTION
This reverts the bootstrap version update as some failing runs in url-map and lb test suites were observed after this went in.