### PR TITLE
Adding a wait-and-retry logic during the initial cluster connectivity check in the base test class

### DIFF
--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -466,11 +466,18 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         if isinstance(err, urllib3.exceptions.MaxRetryError):
             return self._handle_exception(err.reason) if err.reason else None
 
-        # We consider all `NewConnectionError`s as caused by a k8s
-        # API server restart. `NewConnectionError`s we've seen:
+        # We consider all `NewConnectionError`s and `ConnectTimeoutError`s
+        # as caused by a k8s API server restart.
+        # Errors we've seen:
         #   - [Errno 110] Connection timed out
         #   - [Errno 111] Connection refused
-        if isinstance(err, urllib3.exceptions.NewConnectionError):
+        if isinstance(
+            err,
+            (
+                urllib3.exceptions.NewConnectionError,
+                urllib3.exceptions.ConnectTimeoutError,
+            ),
+        ):
             return _server_restart_retryer()
 
         # We consider all `ProtocolError`s with "Connection aborted" message

--- a/framework/xds_k8s_testcase.py
+++ b/framework/xds_k8s_testcase.py
@@ -245,9 +245,21 @@ class XdsKubernetesBaseTestCase(
         cls.check_local_certs = _CHECK_LOCAL_CERTS.value
 
         # Resource managers
-        cls.k8s_api_manager = k8s.KubernetesApiManager(
-            xds_k8s_flags.KUBE_CONTEXT.value
+        # FIX: Wrap in a retryer to handle transient GKE control plane timeouts.
+        retryer = retryers.constant_retryer(
+            wait_fixed=datetime.timedelta(seconds=10),
+            attempts=3,
+            log_level=logging.INFO,
         )
+        try:
+            for attempt in retryer:
+                with attempt:
+                    cls.k8s_api_manager = k8s.KubernetesApiManager(
+                        xds_k8s_flags.KUBE_CONTEXT.value
+                    )
+        except retryers.RetryError as e:
+            logger.error("Fatal: Could not establish GKE connectivity.")
+            raise RuntimeError("Fatal: Could not establish GKE connectivity.") from e
 
         if xds_k8s_flags.SECONDARY_KUBE_CONTEXT.value is not None:
             cls.secondary_k8s_api_manager = k8s.KubernetesApiManager(


### PR DESCRIPTION
Changes:
   1. Add a _wait_for_cluster_connectivity method: This method will execute kubectl version (or a similar lightweight probe) in a loop with a backoff.
   2. Update setUpClass: Instead of blindly proceeding with provisioning, call this new verification method.