### PR TITLE
Update bootstrap generator version to latest

### DIFF
--- a/config/common.cfg
+++ b/config/common.cfg
@@ -1,5 +1,5 @@
 --resource_prefix=psm-interop
---td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap:a756beb5f56c84555095aa3622bdddd843fef95a
+--td_bootstrap_image=us-docker.pkg.dev/grpc-testing/trafficdirector/td-grpc-bootstrap@sha256:c8b4813040228b437ab48640632ec8481a5bab67b5bd0cb32afe62ac96d768b8
 
 # The canonical implementation of the xDS test server.
 # Can be used in tests where language-specific xDS test server does not exist,


### PR DESCRIPTION
The latest version of the bootstrap generator supports multi-arch images.