### PR TITLE
[Framework] Add request IDs to POST and PATCH operations for idempotency

### DIFF
--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -661,21 +661,21 @@ class ComputeV1(
         logger.info(
             "Creating compute resource:\n%s", self.resource_pretty_format(body)
         )
-        request_id = uuid.uuid4()
+        request_id = str(uuid.uuid4())
         if region:
             resp = self._execute(
                 collection.insert(
                     project=self.project,
                     region=region,
                     body=body,
-                    request_id=request_id,
+                    requestId=request_id,
                 ),
                 region=region,
             )
         else:
             resp = self._execute(
                 collection.insert(
-                    project=self.project, body=body, request_id=request_id
+                    project=self.project, body=body, requestId=request_id
                 )
             )
         return self.GcpResource(body["name"], resp["targetLink"])
@@ -684,10 +684,10 @@ class ComputeV1(
         logger.info(
             "Patching compute resource:\n%s", self.resource_pretty_format(body)
         )
-        request_id = uuid.uuid4()
+        request_id = str(uuid.uuid4())
         self._execute(
             collection.patch(
-                project=self.project, body=body, request_id=request_id, **kwargs
+                project=self.project, body=body, requestId=request_id, **kwargs
             )
         )
 

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -16,6 +16,7 @@ import datetime
 import enum
 import logging
 from typing import Any, List, Optional, Set
+import uuid
 
 from googleapiclient import discovery
 import googleapiclient.errors
@@ -660,16 +661,22 @@ class ComputeV1(
         logger.info(
             "Creating compute resource:\n%s", self.resource_pretty_format(body)
         )
+        request_id = uuid.uuid4()
         if region:
             resp = self._execute(
                 collection.insert(
-                    project=self.project, region=region, body=body
+                    project=self.project,
+                    region=region,
+                    body=body,
+                    request_id=request_id,
                 ),
                 region=region,
             )
         else:
             resp = self._execute(
-                collection.insert(project=self.project, body=body)
+                collection.insert(
+                    project=self.project, body=body, request_id=request_id
+                )
             )
         return self.GcpResource(body["name"], resp["targetLink"])
 
@@ -677,8 +684,11 @@ class ComputeV1(
         logger.info(
             "Patching compute resource:\n%s", self.resource_pretty_format(body)
         )
+        request_id = uuid.uuid4()
         self._execute(
-            collection.patch(project=self.project, body=body, **kwargs)
+            collection.patch(
+                project=self.project, body=body, request_id=request_id, **kwargs
+            )
         )
 
     def _list_resource(self, collection: discovery.Resource):


### PR DESCRIPTION
This is an attempt to fix a bug (internal reference b/280522546) where a POST or PATCH request will succeed on the server but the client will not receive the success response, and then subsequent retries will fail because the resource already exists, or has already been modified.

The attempted fix is to add a `request_id` parameter to those requests, so that retries will hopefully succeed. The [request ID documentation](https://docs.cloud.google.com/compute/docs/reference/rest/v1/urlMaps/insert#query-parameters) describes the parameter like this:

> An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.