### PR TITLE
framework: add retries to GCP API get operations

### DIFF
--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -572,7 +572,9 @@ class GcpStandardCloudApiResource(GcpProjectApiResource, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def _get_resource(self, collection: discovery.Resource, full_name):
-        resource = collection.get(name=full_name).execute()
+        resource = collection.get(name=full_name).execute(
+            num_retries=self._GCP_API_RETRIES
+        )
         logger.info(
             "Loaded %s:\n%s", full_name, self.resource_pretty_format(resource)
         )

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -432,7 +432,7 @@ class ComputeV1(
         neg = (
             self.api.networkEndpointGroups()
             .get(project=self.project, networkEndpointGroup=name, zone=zone)
-            .execute()
+            .execute(num_retries=self._GCP_API_RETRIES)
         )
         # TODO(sergiitk): dataclass
         return neg
@@ -575,7 +575,7 @@ class ComputeV1(
                 backendService=backend_service.name,
                 body={"group": backend.url},
             )
-            .execute()
+            .execute(num_retries=self._GCP_API_RETRIES)
         )
 
     def create_neg_serverless(self, name: str, region: str, service_name: str):
@@ -635,7 +635,9 @@ class ComputeV1(
     def _get_resource(
         self, collection: discovery.Resource, **kwargs
     ) -> "GcpResource":
-        resp = collection.get(project=self.project, **kwargs).execute()
+        resp = collection.get(project=self.project, **kwargs).execute(
+            num_retries=self._GCP_API_RETRIES
+        )
         logger.info(
             "Loaded compute resource:\n%s", self.resource_pretty_format(resp)
         )


### PR DESCRIPTION
Adds `num_retries=self._GCP_API_RETRIES` to all `execute()` calls in `_get_resource` and health check paths. This helps mitigate HTTP 429 (Concurrent Operations Limit) errors from the Network Services API.