### PR TITLE
fix cloud run test

### DIFF
--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -387,8 +387,6 @@ class ComputeV1(
         name: str,
         url_map: "GcpResource",
         validate_for_proxyless: bool = True,
-        *,
-        region: Optional[str] = None,
     ) -> "GcpResource":
         body = {
             "name": name,
@@ -400,9 +398,7 @@ class ComputeV1(
             body,
         )
 
-    def delete_target_grpc_proxy(
-        self, name, *, region: Optional[str] = None
-    ):
+    def delete_target_grpc_proxy(self, name):
         self._delete_resource(
             self.api.targetGrpcProxies(),
             "targetGrpcProxy",

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -395,28 +395,18 @@ class ComputeV1(
             "url_map": url_map.url,
             "validate_for_proxyless": validate_for_proxyless,
         }
-        collection = (
-            self.api.regionTargetGrpcProxies()
-            if region
-            else self.api.targetGrpcProxies()
-        )
         return self._insert_resource(
-            collection,
+            self.api.targetGrpcProxies(),
             body,
-            region=region,
         )
 
-    def delete_target_grpc_proxy(self, name, *, region: Optional[str] = None):
-        collection = (
-            self.api.regionTargetGrpcProxies()
-            if region
-            else self.api.targetGrpcProxies()
-        )
+    def delete_target_grpc_proxy(
+        self, name, *, region: Optional[str] = None
+    ):
         self._delete_resource(
-            collection,
+            self.api.targetGrpcProxies(),
             "targetGrpcProxy",
             name,
-            region=region,
         )
 
     def create_target_http_proxy(

--- a/framework/infrastructure/mesh_resource_manager/cloud_run_mesh_manager.py
+++ b/framework/infrastructure/mesh_resource_manager/cloud_run_mesh_manager.py
@@ -50,7 +50,7 @@ class CloudRunMeshManager(td_base.TrafficDirectorAppNetManager):
         )
 
         # Settings
-        self.region = region
+        self.serverless_region = region
 
         # Managed resources
         self.neg: Optional[GcpResource] = None
@@ -90,10 +90,10 @@ class CloudRunMeshManager(td_base.TrafficDirectorAppNetManager):
         name = self.make_resource_name(self.NEG_NAME)
         logger.info("Creating serverless NEG %s", name)
         neg = self.compute.create_neg_serverless(
-            name, self.region, service_name
+            name, self.serverless_region, service_name
         )
         logger.info("Loading NEG %s", neg)
-        self.neg = self.compute.get_neg_serverless(name, self.region)
+        self.neg = self.compute.get_neg_serverless(name, self.serverless_region)
         return neg
 
     def delete_neg_serverless(self, force=False):
@@ -104,7 +104,7 @@ class CloudRunMeshManager(td_base.TrafficDirectorAppNetManager):
         else:
             return
         logger.info("Deleting serverless NEG %s", name)
-        self.compute.delete_neg_serverless(name, self.region)
+        self.compute.delete_neg_serverless(name, self.serverless_region)
         self.neg = None
 
     def cleanup(self, *, force=False):

--- a/framework/infrastructure/traffic_director.py
+++ b/framework/infrastructure/traffic_director.py
@@ -659,9 +659,12 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
             target_proxy_type,
             self.url_map.name,
         )
-        self.target_proxy = create_proxy_fn(
-            name, self.url_map, region=self.region
-        )
+        if self.target_proxy_is_http:
+            self.target_proxy = create_proxy_fn(
+                name, self.url_map, region=self.region
+            )
+        else:
+            self.target_proxy = create_proxy_fn(name, self.url_map)
 
     def create_target_proxy_ipv6(self):
         name = self.make_resource_name(self.TARGET_PROXY_NAME_IPV6)
@@ -685,7 +688,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
         else:
             return
         logger.info('Deleting Target GRPC proxy "%s"', name)
-        self.compute.delete_target_grpc_proxy(name, region=self.region)
+        self.compute.delete_target_grpc_proxy(name)
         self.target_proxy = None
         self.target_proxy_is_http = False
 
@@ -723,7 +726,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
             )
             self.alternative_target_proxy = (
                 self.compute.create_target_grpc_proxy(
-                    name, self.alternative_url_map, False, region=self.region
+                    name, self.alternative_url_map, False
                 )
             )
         else:
@@ -737,7 +740,7 @@ class TrafficDirectorManager:  # pylint: disable=too-many-public-methods
         else:
             return
         logger.info('Deleting alternative Target GRPC proxy "%s"', name)
-        self.compute.delete_target_grpc_proxy(name, region=self.region)
+        self.compute.delete_target_grpc_proxy(name)
         self.alternative_target_proxy = None
 
     def find_unused_forwarding_rule_port(


### PR DESCRIPTION
In `CloudRunMeshManager`, tracking the region for the Serverless NEG was accidentally done by setting `self.region = region`. However, because `CloudRunMeshManager` inherits from `TrafficDirectorManager`, this shadowed the base class's global `self.region` property. This inadvertently forced all Cloud Run tests (inbound, outbound, and spiffe) to behave as regional tests, which caused them to attempt to deploy regional Traffic Director components (backend services, routes) instead of global ones, leading to 404 Not Found API errors.
Fixed it by renaming `self.region` to `self.serverless_region` in `CloudRunMeshManager` to avoid scope collision with the base class, ensuring TD resources deploy globally while the Serverless NEGs deploy regionally.

There was one more issue, which was caught during deleting the resources. The Regional TD PR introduced a conditional branch in `compute.py` to route calls to `self.api.regionTargetGrpcProxies()` if a region was provided. However, GCP `TargetGrpcProxy` resources are strictly global objects and the API SDK has no such regional attribute. This caused regional tests to crash with an `AttributeError` during the `delete_target_grpc_proxy` teardown phase. Because the teardown crashed midway, it abandoned the rest of the deletion sequence, leaving dangling health checks and URL maps in the test project and causing 409 Already Exists conflicts on subsequent runs. Fix: Removed the regional logic and region arguments from `create_target_grpc_proxy` and `delete_target_grpc_proxy` in `compute.py`, guaranteeing they always route to the global `targetGrpcProxies()` API. Updated the `traffic_director.py` dispatcher to stop passing the region argument when provisioning gRPC proxies.