### PR TITLE
Add OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0 to allow metrics scraping

### DIFF
--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -102,6 +102,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+            - name: OTEL_EXPORTER_PROMETHEUS_HOST
+              value: "0.0.0.0"
             % endif
           volumeMounts:
             - mountPath: /tmp/grpc-xds/

--- a/kubernetes-manifests/gamma/client.deployment.yaml
+++ b/kubernetes-manifests/gamma/client.deployment.yaml
@@ -64,6 +64,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+            - name: OTEL_EXPORTER_PROMETHEUS_HOST
+              value: "0.0.0.0"
           ## #####################################################################
           ports:
             - containerPort: ${stats_port}

--- a/kubernetes-manifests/gamma/server.deployment.yaml
+++ b/kubernetes-manifests/gamma/server.deployment.yaml
@@ -62,6 +62,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+            - name: OTEL_EXPORTER_PROMETHEUS_HOST
+              value: "0.0.0.0"
           ## #####################################################################
           ports:
             - containerPort: ${test_port}

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -79,6 +79,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE_NAME)
+            - name: OTEL_EXPORTER_PROMETHEUS_HOST
+              value: "0.0.0.0"
             % endif
           volumeMounts:
             - mountPath: /tmp/grpc-xds/


### PR DESCRIPTION
Recent versions of the OpenTelemetry Java SDK (v1.35.0+) changed the
default Prometheus exporter host from '0.0.0.0' to 'localhost'.

In a Kubernetes environment, this default prevents the metrics endpoint
(port 9464) from being scraped by the test runner or Google Managed
Prometheus (GMP) via the Pod's IP, resulting in "Connection refused"
errors and zero metrics collection.

This commit explicitly sets OTEL_EXPORTER_PROMETHEUS_HOST to '0.0.0.0'
in the deployment manifests to ensure the exporter listens on all
interfaces.

Test invocation on local repo: https://btx.cloud.google.com/invocations/6c0e1d6c-89e4-4524-993a-db61ce5e3c5f

b/524499374