### PR TITLE
Increase memory resources for circuit breaking tests

### DIFF
--- a/framework/test_app/runners/k8s/k8s_xds_client_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_client_runner.py
@@ -33,6 +33,8 @@ class ClientDeploymentArgs:
     csm_canonical_service_name: str = ""
     enable_dualstack: bool = False
     is_trusted_xds_server_experimental: bool = False
+    memory_limit: str = "512Mi"
+    memory_request: str = "512Mi"
 
     def as_dict(self):
         return dataclasses.asdict(self)

--- a/framework/test_app/runners/k8s/k8s_xds_server_runner.py
+++ b/framework/test_app/runners/k8s/k8s_xds_server_runner.py
@@ -39,6 +39,8 @@ class ServerDeploymentArgs:
     csm_canonical_service_name: str = ""
     enable_dualstack: bool = False
     enable_spiffe: bool = False
+    memory_limit: str = "512Mi"
+    memory_request: str = "512Mi"
 
     def as_dict(self):
         return {
@@ -51,6 +53,8 @@ class ServerDeploymentArgs:
             "csm_canonical_service_name": self.csm_canonical_service_name,
             "enable_dualstack": self.enable_dualstack,
             "enable_spiffe": self.enable_spiffe,
+            "memory_limit": self.memory_limit,
+            "memory_request": self.memory_request,
         }
 
 

--- a/kubernetes-manifests/client.deployment.yaml
+++ b/kubernetes-manifests/client.deployment.yaml
@@ -110,10 +110,10 @@ spec:
           resources:
             limits:
               cpu: 800m
-              memory: 512Mi
+              memory: ${memory_limit}
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: ${memory_request}
       initContainers:
         - name: grpc-td-init
           image: ${td_bootstrap_image}

--- a/kubernetes-manifests/server.deployment.yaml
+++ b/kubernetes-manifests/server.deployment.yaml
@@ -88,10 +88,10 @@ spec:
           resources:
             limits:
               cpu: 800m
-              memory: 512Mi
+              memory: ${memory_limit}
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: ${memory_request}
       initContainers:
         - name: grpc-td-init
           image: ${td_bootstrap_image}

--- a/tests/circuit_breaking_test.py
+++ b/tests/circuit_breaking_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import dataclasses
 import logging
 
 from absl import flags
@@ -36,6 +37,8 @@ _QPS = 100
 _INITIAL_UNARY_MAX_REQUESTS = 500
 _INITIAL_EMPTY_MAX_REQUESTS = 1000
 _UPDATED_UNARY_MAX_REQUESTS = 800
+_MEMORY_LIMIT = "2Gi"
+_MEMORY_REQUEST = "1Gi"
 
 
 class CircuitBreakingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
@@ -52,6 +55,42 @@ class CircuitBreakingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             # TODO(https://github.com/grpc/grpc-go/issues/6288): use go server.
             # TODO(https://github.com/grpc/grpc/issues/33134): use python server.
             cls.server_image = xds_k8s_flags.SERVER_IMAGE_CANONICAL.value
+
+    def initKubernetesServerRunner(self, **kwargs) -> _KubernetesServerRunner:
+        deployment_args = kwargs.pop("deployment_args", None)
+        if deployment_args is None:
+            deployment_args = k8s_xds_server_runner.ServerDeploymentArgs(
+                memory_limit=_MEMORY_LIMIT, memory_request=_MEMORY_REQUEST
+            )
+        else:
+            deployment_args = (
+                dataclasses.replace(  # pylint: disable=too-many-function-args
+                    deployment_args,
+                    memory_limit=_MEMORY_LIMIT,
+                    memory_request=_MEMORY_REQUEST,
+                )
+            )
+        return super().initKubernetesServerRunner(
+            deployment_args=deployment_args, **kwargs
+        )
+
+    def initKubernetesClientRunner(self, **kwargs) -> _XdsTestClient:
+        deployment_args = kwargs.pop("deployment_args", None)
+        if deployment_args is None:
+            deployment_args = xds_k8s_testcase.ClientDeploymentArgs(
+                memory_limit=_MEMORY_LIMIT, memory_request=_MEMORY_REQUEST
+            )
+        else:
+            deployment_args = (
+                dataclasses.replace(  # pylint: disable=too-many-function-args
+                    deployment_args,
+                    memory_limit=_MEMORY_LIMIT,
+                    memory_request=_MEMORY_REQUEST,
+                )
+            )
+        return super().initKubernetesClientRunner(
+            deployment_args=deployment_args, **kwargs
+        )
 
     def setUp(self):
         super().setUp()
@@ -72,6 +111,9 @@ class CircuitBreakingTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             enable_workload_identity=self.enable_workload_identity,
             workload_identity_iam_policy_binding=self.workload_identity_iam_policy_binding,
             reuse_namespace=True,
+            deployment_args=k8s_xds_server_runner.ServerDeploymentArgs(
+                memory_limit=_MEMORY_LIMIT, memory_request=_MEMORY_REQUEST
+            ),
         )
 
     def cleanup(self):


### PR DESCRIPTION
     Circuit breaking tests can hold up to 1,800 concurrent RPCs open using
     the 'keep-open' behavior. This high concurrency leads to pod
     termination or eviction when using the default 512Mi memory limit.

     This change:
     - Parametrizes memory limit and request in ClientDeploymentArgs and
       ServerDeploymentArgs runner configurations.
     - Updates Kubernetes deployment manifests to use these parameters.
     - Overrides memory resources in CircuitBreakingTest to use a 2Gi limit
       and 1Gi request for all client and server pods.

     Default memory resources remain at 512Mi for all other tests.

Metabug: b/524899034

[Ad-hoc test run](http://shortn/_iyBdFQnwAz)