### PR TITLE
infra: Use exponential backoff for GCP API retries

### DIFF
--- a/framework/helpers/retryers.py
+++ b/framework/helpers/retryers.py
@@ -91,6 +91,44 @@ def exponential_retryer_with_timeout(
     )
 
 
+def exponential_retryer_with_attempts(
+    *,
+    wait_min: timedelta,
+    wait_max: timedelta,
+    attempts: int,
+    retry_on_exceptions: Optional[_ExceptionClasses] = None,
+    retry_on_predicate: Optional[Callable[[BaseException], bool]] = None,
+    logger: Optional[logging.Logger] = None,
+    log_level: Optional[int] = logging.DEBUG,
+) -> Retrying:
+    if logger is None:
+        logger = retryers_logger
+    if log_level is None:
+        log_level = logging.DEBUG
+
+    retry_conditions = []
+    if retry_on_exceptions:
+        retry_conditions.append(
+            tenacity.retry_if_exception_type(retry_on_exceptions)
+        )
+    if retry_on_predicate:
+        retry_conditions.append(tenacity.retry_if_exception(retry_on_predicate))
+
+    if not retry_conditions:
+        retry_conditions.append(tenacity.retry_if_exception_type(Exception))
+
+    retry_error_callback = _on_error_callback(attempts=attempts)
+    return Retrying(
+        retry=tenacity.retry_any(*retry_conditions),
+        wait=wait.wait_exponential(
+            min=wait_min.total_seconds(), max=wait_max.total_seconds()
+        ),
+        stop=stop.stop_after_attempt(attempts),
+        before_sleep=_before_sleep_log(logger, log_level),
+        retry_error_callback=retry_error_callback,
+    )
+
+
 def constant_retryer(
     *,
     wait_fixed: timedelta,

--- a/framework/infrastructure/gcp/api.py
+++ b/framework/infrastructure/gcp/api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import abc
 import contextlib
+import datetime
 import functools
 import json
 import logging
@@ -34,6 +35,7 @@ import googleapiclient.model
 import tenacity
 import yaml
 
+from framework.helpers import retryers
 import framework.helpers.highlighter
 
 logger = logging.getLogger(__name__)
@@ -135,8 +137,7 @@ class GcpApiManager:
     @property
     @functools.lru_cache(None)
     def private_api_key(self):
-        """
-        Private API key.
+        """Private API key.
 
         Return API key credential that identifies a GCP project allow-listed for
         accessing private API discovery documents.
@@ -362,8 +363,7 @@ class TransportError(Error):
 
 
 class OperationError(Error):
-    """
-    Operation was not successful.
+    """Operation was not successful.
 
     Assuming Operation based on Google API Style Guide:
     https://cloud.google.com/apis/design/design_patterns#long_running_operations
@@ -453,6 +453,29 @@ class GcpProjectApiResource:
         self.project: str = project
         self._highlighter = _HighlighterYaml()
 
+    @staticmethod
+    def _is_retryable_api_error(error: Exception) -> bool:
+        return isinstance(error, _HttpError) and error.resp.status in (
+            429,
+            500,
+            502,
+            503,
+            504,
+        )
+
+    def _get_api_retryer(
+        self, num_retries: Optional[int] = None
+    ) -> retryers.Retrying:
+        if num_retries is None:
+            num_retries = self._GCP_API_RETRIES
+        return retryers.exponential_retryer_with_attempts(
+            wait_min=datetime.timedelta(seconds=1),
+            wait_max=datetime.timedelta(seconds=10),
+            attempts=num_retries + 1,
+            retry_on_predicate=self._is_retryable_api_error,
+            logger=logger,
+        )
+
     # TODO(sergiitk): in upcoming GCP refactoring, differentiate between
     #   _execute for LRO (Long Running Operations), and immediate operations.
     def _execute(
@@ -470,14 +493,15 @@ class GcpProjectApiResource:
           ResponseError if the response was not a 2xx.
           TransportError if a transport error has occurred.
         """
-        if num_retries is None:
-            num_retries = self._GCP_API_RETRIES
+        retryer = self._get_api_retryer(num_retries)
         try:
-            return request.execute(num_retries=num_retries)
-        except _HttpError as error:
-            raise ResponseError(error)
+            return retryer(request.execute, num_retries=0)
+        except (retryers.RetryError, _HttpError) as error:
+            if isinstance(error, retryers.RetryError):
+                error = error.exception()
+            raise ResponseError(error) from error
         except _HttpLib2Error as error:
-            raise TransportError(error)
+            raise TransportError(error) from error
 
     def resource_pretty_format(
         self,
@@ -572,7 +596,10 @@ class GcpStandardCloudApiResource(GcpProjectApiResource, metaclass=abc.ABCMeta):
         raise NotImplementedError
 
     def _get_resource(self, collection: discovery.Resource, full_name):
-        resource = collection.get(name=full_name).execute()
+        retryer = self._get_api_retryer()
+        resource = retryer(
+            collection.get(name=full_name).execute, num_retries=0
+        )
         logger.info(
             "Loaded %s:\n%s", full_name, self.resource_pretty_format(resource)
         )
@@ -598,7 +625,8 @@ class GcpStandardCloudApiResource(GcpProjectApiResource, metaclass=abc.ABCMeta):
         request: HttpRequest,
         timeout_sec: int = GcpProjectApiResource._WAIT_FOR_OPERATION_SEC,
     ):
-        operation = request.execute(num_retries=self._GCP_API_RETRIES)
+        retryer = self._get_api_retryer()
+        operation = retryer(request.execute, num_retries=0)
         logger.debug("Operation %s", operation)
         self._wait(operation["name"], timeout_sec)
 

--- a/framework/infrastructure/gcp/compute.py
+++ b/framework/infrastructure/gcp/compute.py
@@ -713,8 +713,8 @@ class ComputeV1(
         Args:
             name: The name of the NEG.
             region: The region in which to create the NEG.
-            service_name: The name of the Cloud Run service.
-            service_name format is "namespaces/{namespace}/services/{service}"
+            service_name: The name of the Cloud Run service. service_name format
+              is "namespaces/{namespace}/services/{service}"
 
         Returns:
             The NEG selfLink URL
@@ -770,7 +770,11 @@ class ComputeV1(
     ) -> "GcpResource":
         if region:
             kwargs["region"] = region
-        resp = collection.get(project=self.project, **kwargs).execute()
+        retryer = self._get_api_retryer()
+        resp = retryer(
+            collection.get(project=self.project, **kwargs).execute,
+            num_retries=0,
+        )
         logger.info(
             "Loaded compute resource:\n%s", self.resource_pretty_format(resp)
         )
@@ -790,9 +794,8 @@ class ComputeV1(
         }
         if region:
             kwargs["region"] = region
-        resp = collection.list(**kwargs).execute(
-            num_retries=self._GCP_API_RETRIES
-        )
+        retryer = self._get_api_retryer()
+        resp = retryer(collection.list(**kwargs).execute, num_retries=0)
         if "kind" not in resp:
             # TODO(sergiitk): better error
             raise ValueError('List response "kind" is missing')
@@ -838,8 +841,10 @@ class ComputeV1(
         )
 
     def _list_resource(self, collection: discovery.Resource):
-        return collection.list(project=self.project).execute(
-            num_retries=self._GCP_API_RETRIES
+        retryer = self._get_api_retryer()
+        return retryer(
+            collection.list(project=self.project).execute,
+            num_retries=0,
         )
 
     def _delete_resource(
@@ -900,7 +905,9 @@ class ComputeV1(
             )
             request.headers[DEBUG_HEADER_KEY] = self.gfe_debug_header
             request.add_response_callback(self._log_debug_header)
-        operation = request.execute(num_retries=self._GCP_API_RETRIES)
+
+        retryer = self._get_api_retryer()
+        operation = retryer(request.execute, num_retries=0)
         logger.debug("Operation %s", operation)
         return self._wait(operation["name"], timeout_sec, region)
 
@@ -937,7 +944,5 @@ class ComputeV1(
         logger.debug("Completed operation: %s", operation)
         if "error" in operation:
             # This shouldn't normally happen: gcp library raises on errors.
-            raise Exception(
-                f"Compute operation {operation_id} failed: {operation}"
-            )
+            raise gcp.api.OperationError("compute", operation)
         return operation


### PR DESCRIPTION
Refactor GCP API retry logic to use a centralized exponential backoff strategy instead of aggressive internal library retries. This addresses 429 (Too Many Requests) and 500 (Internal Error) failures observed in dense tests like security_test.py.

- Add exponential_retryer_with_attempts to framework/helpers/retryers.py.
- Update GcpProjectApiResource and ComputeV1 to use the new smart retryer for mutations, lookups, and listings.
- Disable internal library retries (num_retries=0) to give full control to the smart retryer and prevent "double spamming" the API.
- Fix missing retry logic in _get_resource lookups.

This approach ensures that when rate limits or transient flakes occur, the driver waits and backs off before retrying, providing a more resilient integration with GCP services.

Metabug b/522968808

[ad-hoc test run](http://shortn/_nehboLtOPq)