### PR TITLE
kokoro: Execute test cases concurrently

### DIFF
--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -519,12 +519,36 @@ psm::run() {
 psm::run::test_suite() {
   local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
   cd "${TEST_DRIVER_FULL_DIR}"
+
+  # Export variables needed by subshells
+  export TEST_XML_OUTPUT_DIR
+  export TEST_DRIVER_FLAGFILE
+  export KUBE_CONTEXT
+  export TESTING_VERSION
+  export CLIENT_IMAGE_NAME
+  export GIT_COMMIT
+  export SERVER_IMAGE_USE_CANONICAL
+  export SERVER_IMAGE_NAME
+  export SECONDARY_KUBE_CONTEXT
+  export GRPC_LANGUAGE
+  export PSM_EXTRA_FLAGS
+  export VIRTUAL_ENV
+
+  # Export functions needed by subshells
+  export -f psm::tools::log
+  export -f psm::tools::run_verbose
+  export -f psm::run::finalize_test_flags
+  export -f "psm::${test_suite}::run_test"
+  export -f psm::run::test
+
   local failed_tests=0
-  for test_name in "${TESTS[@]}"; do
-    psm::run::test "${test_suite}" "${test_name}" || (( ++failed_tests ))
-    psm::tools::log "Finished ${test_suite} suite test: ${test_name}"
-    echo
-  done
+  local jobs="${PSM_PARALLEL_JOBS:-2}"
+
+  psm::tools::log "Running ${test_suite} suite tests in parallel with ${jobs} jobs"
+  # We use --line-buffer to see output in real-time, preventing half-lines from mixing.
+  # We use --shell bash to ensure it runs in bash.
+  parallel --shell bash --line-buffer --jobs "${jobs}" psm::run::test "${test_suite}" ::: "${TESTS[@]}" || failed_tests=$?
+
   psm::tools::log "Failed test suites: ${failed_tests}"
 }
 
@@ -575,8 +599,11 @@ psm::run::test() {
   fi
 
   psm::tools::log "Running ${test_suite} suite test: ${test_name}" |& tee "${test_log}"
-  # Must be the last line.
-  "psm::${test_suite}::run_test" "${test_name}" |& tee -a "${test_log}"
+  local exit_code=0
+  "psm::${test_suite}::run_test" "${test_name}" |& tee -a "${test_log}" || exit_code=$?
+  psm::tools::log "Finished ${test_suite} suite test: ${test_name}"
+  echo
+  return ${exit_code}
 }
 
 #######################################
@@ -1278,7 +1305,8 @@ kokoro_install_dependencies() {
   sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install --auto-remove \
     "python${PYTHON_VERSION}-venv" \
     google-cloud-sdk-gke-gcloud-auth-plugin \
-    kubectl
+    kubectl \
+    parallel
   sudo rm -rf /var/lib/apt/lists
 }
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -575,6 +575,7 @@ psm::run::test_suite() {
 #   Test xUnit report to ${TEST_XML_OUTPUT_DIR}/${test_name}/sponge_log.xml
 #######################################
 psm::run::test() {
+  set -eo pipefail
   # Test driver usage: https://github.com/grpc/psm-interop#basic-usage
   local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
   local test_name="${2:?${FUNCNAME[0]} missing the test name argument}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -520,7 +520,7 @@ psm::run::test_suite() {
   local test_suite="${1:?${FUNCNAME[0]} missing the test suite argument}"
   cd "${TEST_DRIVER_FULL_DIR}"
 
-  # Export variables needed by subshells
+  # Export variables needed by subshells.
   export TEST_XML_OUTPUT_DIR
   export TEST_DRIVER_FLAGFILE
   export KUBE_CONTEXT
@@ -534,12 +534,10 @@ psm::run::test_suite() {
   export PSM_EXTRA_FLAGS
   export VIRTUAL_ENV
 
-  # Export functions needed by subshells
-  export -f psm::tools::log
-  export -f psm::tools::run_verbose
-  export -f psm::run::finalize_test_flags
-  export -f "psm::${test_suite}::run_test"
-  export -f psm::run::test
+   # Export all functions in the "psm::" namespace.
+   for func in $(declare -F | awk '{print $3}' | grep '^psm::'); do
+       export -f "$func"
+   done
 
   local failed_tests=0
   local jobs="${PSM_PARALLEL_JOBS:-2}"

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -235,13 +235,13 @@ psm::dualstack::get_tests() {
     "dualstack_test"
     "affinity_test"
     "api_listener_test"
-    "app_net_test"
-    "change_backend_service_test"
-    "custom_lb_test"
-    "round_robin_test"
-    "circuit_breaking_test"
-    "outlier_detection_test"
-    "remove_neg_test"
+    # "app_net_test"
+    # "change_backend_service_test"
+    # "custom_lb_test"
+    # "round_robin_test"
+    # "circuit_breaking_test"
+    # "outlier_detection_test"
+    # "remove_neg_test"
   )
 }
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -540,10 +540,17 @@ psm::run::test_suite() {
    done
 
   local failed_tests=0
-  local jobs="${PSM_PARALLEL_JOBS:-2}"
+  # TODO(b/526886100): Make the parallelism configurable using a function
+  # parameter.
+  local jobs=1
+  case "${test_suite}" in
+    security | lb | dualstack)
+      jobs=2
+      ;;
+  esac
 
   psm::tools::log "Running ${test_suite} suite tests in parallel with ${jobs} jobs"
-  # We use --line-buffer to see output in real-time, preventing half-lines from 
+  # We use --line-buffer to see output in real-time, preventing half-lines from
   # mixing.
   parallel --line-buffer --jobs "${jobs}" psm::run::test "${test_suite}" ::: "${TESTS[@]}" || failed_tests=$?
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -540,7 +540,7 @@ psm::run::test_suite() {
    done
 
   local failed_tests=0
-  # TODO(b/526886100): Make the parallelism configurable using a function
+  # TODO: b/535109852 - Make the parallelism configurable using a function
   # parameter.
   local jobs=1
   case "${test_suite}" in

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -235,13 +235,13 @@ psm::dualstack::get_tests() {
     "dualstack_test"
     "affinity_test"
     "api_listener_test"
-    # "app_net_test"
-    # "change_backend_service_test"
-    # "custom_lb_test"
-    # "round_robin_test"
-    # "circuit_breaking_test"
-    # "outlier_detection_test"
-    # "remove_neg_test"
+    "app_net_test"
+    "change_backend_service_test"
+    "custom_lb_test"
+    "round_robin_test"
+    "circuit_breaking_test"
+    "outlier_detection_test"
+    "remove_neg_test"
   )
 }
 

--- a/.kokoro/psm_interop_kokoro_lib.sh
+++ b/.kokoro/psm_interop_kokoro_lib.sh
@@ -545,9 +545,9 @@ psm::run::test_suite() {
   local jobs="${PSM_PARALLEL_JOBS:-2}"
 
   psm::tools::log "Running ${test_suite} suite tests in parallel with ${jobs} jobs"
-  # We use --line-buffer to see output in real-time, preventing half-lines from mixing.
-  # We use --shell bash to ensure it runs in bash.
-  parallel --shell bash --line-buffer --jobs "${jobs}" psm::run::test "${test_suite}" ::: "${TESTS[@]}" || failed_tests=$?
+  # We use --line-buffer to see output in real-time, preventing half-lines from 
+  # mixing.
+  parallel --line-buffer --jobs "${jobs}" psm::run::test "${test_suite}" ::: "${TESTS[@]}" || failed_tests=$?
 
   psm::tools::log "Failed test suites: ${failed_tests}"
 }

--- a/tests/dualstack_test.py
+++ b/tests/dualstack_test.py
@@ -128,7 +128,6 @@ class DualStackTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             self.td.create_health_check()
 
         with self.subTest("01_create_backend_service"):
-            self.fail("Arjan: Forced test failure in 01_create_backend_service")
             self.td.create_backend_service()
 
         with self.subTest("02_setup_routing_rule_map_for_grpc"):

--- a/tests/dualstack_test.py
+++ b/tests/dualstack_test.py
@@ -128,6 +128,7 @@ class DualStackTest(xds_k8s_testcase.RegularXdsKubernetesTestCase):
             self.td.create_health_check()
 
         with self.subTest("01_create_backend_service"):
+            self.fail("Arjan: Forced test failure in 01_create_backend_service")
             self.td.create_backend_service()
 
         with self.subTest("02_setup_routing_rule_map_for_grpc"):


### PR DESCRIPTION
Related Issue: b/526886100

---

### Context & Summary
This change enables concurrent execution of test cases within the Security, LB, and DualStack test suites. Shifting from sequential execution to a parallelized model drastically reduces overall execution times and resolves the timeouts observed in our scheduled test runs.

The CSM suite remains unaffected and will continue to execute sequentially to prevent any shared resource conflicts.

---

### Performance Improvements

| Test Suite | Concurrent jobs | Before (mins) | After (mins) | Delta / Reduction (%) |
|---|---|---|---|---|
| Security | 2 | 220 | 122 | -44.5% |
| LB | 2 | 281 | 182 | -35.2% |
| DualStack | 2 | 195 | 115 | -41% |
| PSM Light | 1 | 5 | 5 | 0%  |


Concurrency in LB suite on master is slightly reduced due to a long bootstrap generator test that runs at the end.

---

### Test Runs
* Security: [Logs](https://source.cloud.google.com/results/invocations/861c691e-c1c6-4532-9532-374da59749ff)
* LB: [Logs](https://source.cloud.google.com/results/invocations/19f55780-19f5-4f50-8d94-f30ca52dca5f)
* DualStack: [Logs](https://source.cloud.google.com/results/invocations/0ca1e9a6-a0d5-4157-8f02-45c9b6a788ed)
* PSM Light (unaffected): [Logs](https://source.cloud.google.com/results/invocations/b2be5f78-e641-4e9a-a257-c758776a44ed)
