### PR TITLE
Enable gamma baseline test for master in all languages

### DIFF
--- a/tests/gamma/gamma_baseline_test.py
+++ b/tests/gamma/gamma_baseline_test.py
@@ -32,7 +32,7 @@ class GammaBaselineTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     @staticmethod
     @override
     def is_supported(config: skips.TestConfig) -> bool:
-        return config.version in ("master", None)
+        return config.version in ("master", "dev-master", None)
 
     def test_ping_pong(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma

--- a/tests/gamma/gamma_baseline_test.py
+++ b/tests/gamma/gamma_baseline_test.py
@@ -32,7 +32,7 @@ class GammaBaselineTest(xds_gamma_testcase.GammaXdsKubernetesTestCase):
     @staticmethod
     @override
     def is_supported(config: skips.TestConfig) -> bool:
-        return False
+        return config.version in ("master", None)
 
     def test_ping_pong(self):
         # TODO(sergiitk): [GAMMA] Consider moving out custom gamma


### PR DESCRIPTION
The gamma tests were disabled in https://github.com/grpc/psm-interop/pull/213 due to b/427414245

Issue is not fixed, hence re-enabling it for just one of the tests in only master so that we can keep the issue active and prioritise the fix for it.