### PR TITLE
Handle 404 error correctly on `_get_resource` retry

### DIFF
--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -464,6 +464,7 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
                             # This will raise NotFound and stop retries
                             self._handle_api_exception(e)
                         raise
+
                 return retryer(method_with_404_handler, *args, **kwargs)
             raise
 

--- a/framework/infrastructure/k8s.py
+++ b/framework/infrastructure/k8s.py
@@ -455,7 +455,16 @@ class KubernetesNamespace:  # pylint: disable=too-many-public-methods
         except _RETRY_ON_EXCEPTIONS as err:
             retryer = self._handle_exception(err)
             if retryer is not None:
-                return retryer(method, *args, **kwargs)
+                # Wrap the method to handle 404 error translation neatly.
+                def method_with_404_handler(*w_args, **w_kwargs):
+                    try:
+                        return method(*w_args, **w_kwargs)
+                    except _ApiException as e:
+                        if e.status == 404:
+                            # This will raise NotFound and stop retries
+                            self._handle_api_exception(e)
+                        raise
+                return retryer(method_with_404_handler, *args, **kwargs)
             raise
 
     def _handle_exception(self, err: Exception) -> Optional[retryers.Retrying]:


### PR DESCRIPTION
Some tests are configured with `reuse_namespace=True`. Because of this flag, the Server runner first checks if the namespace exists (using `self.k8s_namespace.get()` -> `_get_resource()`) before attempting to create it. 

We expect this check to return a `404 Not Found ApiException` from the GKE API as the namespace does not exist which is translated in our test driver to `None`, allowing the runner to proceed and create the namespace. 

However, if the first API call fails with `401 Unauthorized` (e.g., due to an expired token), the framework refreshes the credentials and retries. During these retries, if GKE returns `404 Not Found` (since the namespace doesn't exist yet), the framework fails to translate the `404` to `None`. Instead, it retries the `404` until attempts are exhausted and crashes the test with a `RetryError`. 

Internal Ref: b/535964302

This PR fixes it by handling the `404 Error correctly` during the retryer loop.